### PR TITLE
データチャネル機能を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,3 +11,25 @@
 
 ## develop
 
+- [ADD] データチャネルを使ったサンプルを追加する
+    - 以下の三つを追加:
+        - test/messaging-readonly.py
+        - test/messaging-sendonly.py
+        - test/messaging-sendrecv.py
+    - @sile
+- [CHANGE] `SoraConnection.on_message()` コールバックの第二引数の方を `str` から `bytes` に変更する
+    - 文字列以外の任意のバイト列が送受信可能なため
+    - @sile
+- [ADD] `SoraConnection` クラスに `send_data_channel(label: str, data: bytes)` メソッドを追加する
+    - データチャネル経由でメッセージを送信するためのメソッド
+    - 使用するためには `Sora.create_connection()` で以下のオプションを指定する必要がある:
+        - `data_channel_signaling=True`
+        - `data_channels=[{"label": ..., "direction": ..., ...}, ...]`
+    - なお `create_connection()` の後、 `SoraConnection.on_data_channel(label: str)` コールバックが呼び出されるまでは、該当ラベルに対するメッセージ送信は行えないので注意が必要
+    - @sile
+- [ADD] `Sora.create_connection()` メソッドにデータチャネル関連の引数を追加する
+    - 追加したのは以下の引数:
+        - `data_channels`
+        - `data_channel_signaling`
+        - `ignore_disconnect_websocket`
+    - @sile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ dev-dependencies = [
     "opencv-python-headless~=4.7.0.72",
     "sounddevice~=0.4.6",
     "mediapipe~=0.10.0",
+    "autopep8~=2.0.2",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ dev-dependencies = [
     "opencv-python~=4.7.0.72",
     "opencv-python-headless~=4.7.0.72",
     "sounddevice~=0.4.6",
-    "mediapipe~=0.10.0",
     "autopep8~=2.0.2",
 ]
 

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -7,27 +7,12 @@
 #   all-features: false
 
 -e file:.
-absl-py==1.4.0
-attrs==23.1.0
+autopep8==2.0.2
 cffi==1.15.1
-contourpy==1.0.7
-cycler==0.11.0
-flatbuffers==23.5.26
-fonttools==4.39.4
-importlib-resources==5.12.0
-kiwisolver==1.4.4
-matplotlib==3.7.1
-mediapipe==0.10.0
 numpy==1.24.3
-opencv-contrib-python==4.7.0.72
 opencv-python==4.7.0.72
 opencv-python-headless==4.7.0.72
-packaging==23.1
-pillow==9.5.0
-protobuf==3.20.3
+pycodestyle==2.10.0
 pycparser==2.21
-pyparsing==3.0.9
-python-dateutil==2.8.2
-six==1.16.0
 sounddevice==0.4.6
-zipp==3.15.0
+tomli==2.0.1

--- a/src/sora.cpp
+++ b/src/sora.cpp
@@ -44,7 +44,6 @@ std::shared_ptr<SoraConnection> Sora::CreateConnection(
       factory_->GetConnectionContext()->default_network_manager();
   config.socket_factory =
       factory_->GetConnectionContext()->default_socket_factory();
-
   conn->Init(config);
   if (audio_source) {
     conn->SetAudioTrack(audio_source);
@@ -128,55 +127,54 @@ std::vector<sora::SoraSignalingConfig::DataChannel> Sora::ConvertDataChannels(
       throw nb::type_error("Invalid data_channels");
     }
 
-    auto data_channel_object = data_channel_value.as_object();
+    auto object = data_channel_value.as_object();
     sora::SoraSignalingConfig::DataChannel data_channel;
 
-    if (!data_channel_object["label"].is_string()) {
+    if (!object["label"].is_string()) {
       throw nb::type_error("Invalid data_channels");
     }
-    data_channel.label = data_channel_object["label"].as_string();
+    data_channel.label = object["label"].as_string();
 
-    if (!data_channel_object["direction"].is_string()) {
+    if (!object["direction"].is_string()) {
       throw nb::type_error("Invalid data_channels");
     }
-    data_channel.direction = data_channel_object["direction"].as_string();
+    data_channel.direction = object["direction"].as_string();
 
-    if (!data_channel_object["protocol"].is_null()) {
-      if (!data_channel_object["protocol"].is_string()) {
+    if (!object["protocol"].is_null()) {
+      if (!object["protocol"].is_string()) {
         throw nb::type_error("Invalid data_channels");
       }
-      data_channel.protocol.emplace(
-          data_channel_object["protocol"].as_string());
+      data_channel.protocol = object["protocol"].as_string();
     }
 
-    if (!data_channel_object["ordered"].is_null()) {
-      if (!data_channel_object["ordered"].is_bool()) {
+    if (!object["ordered"].is_null()) {
+      if (!object["ordered"].is_bool()) {
         throw nb::type_error("Invalid data_channels");
       }
-      data_channel.ordered = data_channel_object["ordered"].as_bool();
+      data_channel.ordered = object["ordered"].as_bool();
     }
 
-    if (!data_channel_object["compress"].is_null()) {
-      if (!data_channel_object["compress"].is_bool()) {
+    if (!object["compress"].is_null()) {
+      if (!object["compress"].is_bool()) {
         throw nb::type_error("Invalid data_channels");
       }
-      data_channel.compress = data_channel_object["compress"].as_bool();
+      data_channel.compress = object["compress"].as_bool();
     }
 
-    if (!data_channel_object["max_packet_life_time"].is_null()) {
-      if (!data_channel_object["max_packet_life_time"].is_number()) {
+    if (!object["max_packet_life_time"].is_null()) {
+      if (!object["max_packet_life_time"].is_number()) {
         throw nb::type_error("Invalid data_channels");
       }
-      data_channel.max_packet_life_time = boost::json::value_to<int32_t>(
-          data_channel_object["max_packet_life_time"]);
+      data_channel.max_packet_life_time =
+          boost::json::value_to<int32_t>(object["max_packet_life_time"]);
     }
 
-    if (!data_channel_object["max_retransmits"].is_null()) {
-      if (!data_channel_object["max_retransmits"].is_number()) {
+    if (!object["max_retransmits"].is_null()) {
+      if (!object["max_retransmits"].is_number()) {
         throw nb::type_error("Invalid data_channels");
       }
-      data_channel.max_retransmits = boost::json::value_to<int32_t>(
-          data_channel_object["max_retransmits"]);
+      data_channel.max_retransmits =
+          boost::json::value_to<int32_t>(object["max_retransmits"]);
     }
     data_channels.push_back(data_channel);
   }

--- a/src/sora.cpp
+++ b/src/sora.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<SoraConnection> Sora::CreateConnection(
   config.audio = true;
   config.video_codec_type = "VP8";
   config.audio_codec_type = "OPUS";
-  config.metadata = CovertJsonValue(metadata);
+  config.metadata = ConvertJsonValue(metadata);
   config.network_manager =
       factory_->GetConnectionContext()->default_network_manager();
   config.socket_factory =
@@ -67,7 +67,7 @@ SoraVideoSource* Sora::CreateVideoSource() {
   return video_source;
 }
 
-boost::json::value Sora::CovertJsonValue(nb::handle value) {
+boost::json::value Sora::ConvertJsonValue(nb::handle value) {
   if (value.is_none()) {
     return nullptr;
   } else if (nb::isinstance<bool>(value)) {
@@ -82,13 +82,13 @@ boost::json::value Sora::CovertJsonValue(nb::handle value) {
     nb::list nb_list = nb::cast<nb::list>(value);
     boost::json::array json_array;
     for (auto v : nb_list)
-      json_array.emplace_back(CovertJsonValue(value));
+      json_array.emplace_back(ConvertJsonValue(value));
     return json_array;
   } else if (nb::isinstance<nb::dict>(value)) {
     nb::dict nb_dict = nb::cast<nb::dict>(value);
     boost::json::object json_object;
     for (auto [k, v] : nb_dict)
-      json_object.emplace(nb::cast<const char*>(k), CovertJsonValue(v));
+      json_object.emplace(nb::cast<const char*>(k), ConvertJsonValue(v));
     return json_object;
   }
   throw nb::type_error("Invalid JSON value in metadata");

--- a/src/sora.cpp
+++ b/src/sora.cpp
@@ -16,8 +16,8 @@ std::shared_ptr<SoraConnection> Sora::CreateConnection(
     const nb::handle& metadata,
     SoraTrackInterface* audio_source,
     SoraTrackInterface* video_source,
-    bool data_channel_signaling,
-    bool ignore_disconnect_websocket) {
+    std::optional<bool> data_channel_signaling,
+    std::optional<bool> ignore_disconnect_websocket) {
   std::shared_ptr<SoraConnection> conn = std::make_shared<SoraConnection>(this);
   sora::SoraSignalingConfig config;
   config.pc_factory = factory_->GetPeerConnectionFactory();
@@ -31,8 +31,12 @@ std::shared_ptr<SoraConnection> Sora::CreateConnection(
   config.video_codec_type = "VP8";
   config.audio_codec_type = "OPUS";
   config.metadata = ConvertJsonValue(metadata);
-  config.data_channel_signaling = data_channel_signaling;
-  config.ignore_disconnect_websocket = ignore_disconnect_websocket;
+  if (data_channel_signaling) {
+    config.data_channel_signaling.emplace(*data_channel_signaling);
+  }
+  if (ignore_disconnect_websocket) {
+    config.ignore_disconnect_websocket.emplace(*ignore_disconnect_websocket);
+  }
   config.network_manager =
       factory_->GetConnectionContext()->default_network_manager();
   config.socket_factory =

--- a/src/sora.cpp
+++ b/src/sora.cpp
@@ -15,7 +15,9 @@ std::shared_ptr<SoraConnection> Sora::CreateConnection(
     const std::string& client_id,
     const nb::handle& metadata,
     SoraTrackInterface* audio_source,
-    SoraTrackInterface* video_source) {
+    SoraTrackInterface* video_source,
+    bool data_channel_signaling,
+    bool ignore_disconnect_websocket) {
   std::shared_ptr<SoraConnection> conn = std::make_shared<SoraConnection>(this);
   sora::SoraSignalingConfig config;
   config.pc_factory = factory_->GetPeerConnectionFactory();
@@ -29,6 +31,8 @@ std::shared_ptr<SoraConnection> Sora::CreateConnection(
   config.video_codec_type = "VP8";
   config.audio_codec_type = "OPUS";
   config.metadata = ConvertJsonValue(metadata);
+  config.data_channel_signaling = data_channel_signaling;
+  config.ignore_disconnect_websocket = ignore_disconnect_websocket;
   config.network_manager =
       factory_->GetConnectionContext()->default_network_manager();
   config.socket_factory =

--- a/src/sora.h
+++ b/src/sora.h
@@ -25,6 +25,7 @@ class Sora : public DisposePublisher {
       const nb::handle& metadata,
       SoraTrackInterface* audio_source,
       SoraTrackInterface* video_source,
+      const nb::handle& data_channels,
       std::optional<bool> data_channel_signaling,
       std::optional<bool> ignore_disconnect_websocket);
 

--- a/src/sora.h
+++ b/src/sora.h
@@ -2,6 +2,7 @@
 #define SORA_H_
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "dispose_listener.h"
@@ -24,8 +25,8 @@ class Sora : public DisposePublisher {
       const nb::handle& metadata,
       SoraTrackInterface* audio_source,
       SoraTrackInterface* video_source,
-      bool data_channel_signaling,
-      bool ignore_disconnect_websocket);
+      std::optional<bool> data_channel_signaling,
+      std::optional<bool> ignore_disconnect_websocket);
 
   SoraAudioSource* CreateAudioSource(size_t channels, int sample_rate);
   SoraVideoSource* CreateVideoSource();

--- a/src/sora.h
+++ b/src/sora.h
@@ -33,7 +33,10 @@ class Sora : public DisposePublisher {
   SoraVideoSource* CreateVideoSource();
 
  private:
-  boost::json::value ConvertJsonValue(nb::handle value, const char* error_message);
+  boost::json::value ConvertJsonValue(nb::handle value,
+                                      const char* error_message);
+  std::vector<sora::SoraSignalingConfig::DataChannel> ConvertDataChannels(
+      const nb::handle value);
 
   std::unique_ptr<SoraFactory> factory_;
 };

--- a/src/sora.h
+++ b/src/sora.h
@@ -23,7 +23,9 @@ class Sora : public DisposePublisher {
       const std::string& client_id,
       const nb::handle& metadata,
       SoraTrackInterface* audio_source,
-      SoraTrackInterface* video_source);
+      SoraTrackInterface* video_source,
+      bool data_channel_signaling,
+      bool ignore_disconnect_websocket);
 
   SoraAudioSource* CreateAudioSource(size_t channels, int sample_rate);
   SoraVideoSource* CreateVideoSource();

--- a/src/sora.h
+++ b/src/sora.h
@@ -33,7 +33,7 @@ class Sora : public DisposePublisher {
   SoraVideoSource* CreateVideoSource();
 
  private:
-  boost::json::value ConvertJsonValue(nb::handle value);
+  boost::json::value ConvertJsonValue(nb::handle value, const char* error_message);
 
   std::unique_ptr<SoraFactory> factory_;
 };

--- a/src/sora.h
+++ b/src/sora.h
@@ -29,7 +29,7 @@ class Sora : public DisposePublisher {
   SoraVideoSource* CreateVideoSource();
 
  private:
-  boost::json::value CovertJsonValue(nb::handle value);
+  boost::json::value ConvertJsonValue(nb::handle value);
 
   std::unique_ptr<SoraFactory> factory_;
 };

--- a/src/sora_connection.cpp
+++ b/src/sora_connection.cpp
@@ -80,6 +80,10 @@ void SoraConnection::SetVideoTrack(SoraTrackInterface* video_source) {
   video_source_ = video_source;
 }
 
+bool SoraConnection::SendDataChannel(const std::string& label, const std::string& data) {
+  return conn_->SendDataChannel(label, data);
+}
+
 void SoraConnection::OnSetOffer(std::string offer) {
   std::string stream_id = rtc::CreateRandomString(16);
   if (audio_source_) {

--- a/src/sora_connection.cpp
+++ b/src/sora_connection.cpp
@@ -80,7 +80,8 @@ void SoraConnection::SetVideoTrack(SoraTrackInterface* video_source) {
   video_source_ = video_source;
 }
 
-bool SoraConnection::SendDataChannel(const std::string& label, const std::string& data) {
+bool SoraConnection::SendDataChannel(const std::string& label,
+                                     const std::string& data) {
   return conn_->SendDataChannel(label, data);
 }
 

--- a/src/sora_connection.cpp
+++ b/src/sora_connection.cpp
@@ -81,8 +81,8 @@ void SoraConnection::SetVideoTrack(SoraTrackInterface* video_source) {
 }
 
 bool SoraConnection::SendDataChannel(const std::string& label,
-                                     const std::string& data) {
-  return conn_->SendDataChannel(label, data);
+                                     nb::bytes& data) {
+  return conn_->SendDataChannel(label, std::string(data.c_str()));
 }
 
 void SoraConnection::OnSetOffer(std::string offer) {
@@ -130,7 +130,7 @@ void SoraConnection::OnPush(std::string text) {
 
 void SoraConnection::OnMessage(std::string label, std::string data) {
   if (on_message_) {
-    on_message_(label, data);
+    on_message_(label, nb::bytes(data.c_str()));
   }
 }
 

--- a/src/sora_connection.h
+++ b/src/sora_connection.h
@@ -21,6 +21,8 @@
 #include "dispose_listener.h"
 #include "sora_track_interface.h"
 
+namespace nb = nanobind;
+
 class SoraConnection : public sora::SoraSignalingObserver,
                        public DisposePublisher,
                        public DisposeSubscriber {
@@ -36,7 +38,7 @@ class SoraConnection : public sora::SoraSignalingObserver,
   void Disconnect();
   void SetAudioTrack(SoraTrackInterface* audio_source);
   void SetVideoTrack(SoraTrackInterface* video_source);
-  bool SendDataChannel(const std::string& label, const std::string& data);
+  bool SendDataChannel(const std::string& label, nb::bytes& data);
 
   // sora::SoraSignalingObserver
   void OnSetOffer(std::string offer) override;
@@ -55,7 +57,7 @@ class SoraConnection : public sora::SoraSignalingObserver,
   std::function<void(sora::SoraSignalingErrorCode, std::string)> on_disconnect_;
   std::function<void(std::string)> on_notify_;
   std::function<void(std::string)> on_push_;
-  std::function<void(std::string, std::string)> on_message_;
+  std::function<void(std::string, nb::bytes)> on_message_;
   std::function<void(std::shared_ptr<SoraTrackInterface>)> on_track_;
   std::function<void(std::string)> on_data_channel_;
 

--- a/src/sora_connection.h
+++ b/src/sora_connection.h
@@ -36,6 +36,7 @@ class SoraConnection : public sora::SoraSignalingObserver,
   void Disconnect();
   void SetAudioTrack(SoraTrackInterface* audio_source);
   void SetVideoTrack(SoraTrackInterface* video_source);
+  bool SendDataChannel(const std::string& label, const std::string& data);
 
   // sora::SoraSignalingObserver
   void OnSetOffer(std::string offer) override;

--- a/src/sora_sdk_ext.cpp
+++ b/src/sora_sdk_ext.cpp
@@ -203,7 +203,8 @@ NB_MODULE(sora_sdk_ext, m) {
       .def(nb::init<bool>(), "use_hardware_encoder"_a = false)
       .def("create_connection", &Sora::CreateConnection, "signaling_url"_a,
            "role"_a, "channel_id"_a, "client_id"_a = "", "metadata"_a = "",
-           "audio_source"_a = nb::none(), "video_source"_a = nb::none())
+           "audio_source"_a = nb::none(), "video_source"_a = nb::none(),
+           "data_channel_signaling"_a = std::nullopt, "ignore_disconnect_websocket"_a = std::nullopt)
       .def("create_audio_source", &Sora::CreateAudioSource)
       .def("create_video_source", &Sora::CreateVideoSource);
 }

--- a/src/sora_sdk_ext.cpp
+++ b/src/sora_sdk_ext.cpp
@@ -203,8 +203,9 @@ NB_MODULE(sora_sdk_ext, m) {
   nb::class_<Sora>(m, "Sora")
       .def(nb::init<bool>(), "use_hardware_encoder"_a = false)
       .def("create_connection", &Sora::CreateConnection, "signaling_url"_a,
-           "role"_a, "channel_id"_a, "client_id"_a = "", "metadata"_a = "",
+           "role"_a, "channel_id"_a, "client_id"_a = "", "metadata"_a = nb::none(),
            "audio_source"_a = nb::none(), "video_source"_a = nb::none(),
+           "data_channels"_a = nb::none(),
            "data_channel_signaling"_a = nb::none(),
            "ignore_disconnect_websocket"_a = nb::none())
       .def("create_audio_source", &Sora::CreateAudioSource)

--- a/src/sora_sdk_ext.cpp
+++ b/src/sora_sdk_ext.cpp
@@ -16,7 +16,7 @@
 namespace nb = nanobind;
 using namespace nb::literals;
 
-/* 
+/*
  * コールバック関数のメンバー変数は Py_tp_traverse で visit コールバックを呼び出すようにする
  * やっておかないと終了時にリークエラーが発生する
  */
@@ -189,6 +189,7 @@ NB_MODULE(sora_sdk_ext, m) {
                              nb::type_slots(connection_slots))
       .def("connect", &SoraConnection::Connect)
       .def("disconnect", &SoraConnection::Disconnect)
+      .def("send_data_channel", &SoraConnection::SendDataChannel, "label"_a, "data"_a)
       .def_rw("on_set_offer", &SoraConnection::on_set_offer_)
       .def_rw("on_disconnect", &SoraConnection::on_disconnect_)
       .def_rw("on_notify", &SoraConnection::on_notify_)

--- a/src/sora_sdk_ext.cpp
+++ b/src/sora_sdk_ext.cpp
@@ -2,6 +2,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/function.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 
@@ -204,7 +205,8 @@ NB_MODULE(sora_sdk_ext, m) {
       .def("create_connection", &Sora::CreateConnection, "signaling_url"_a,
            "role"_a, "channel_id"_a, "client_id"_a = "", "metadata"_a = "",
            "audio_source"_a = nb::none(), "video_source"_a = nb::none(),
-           "data_channel_signaling"_a = std::nullopt, "ignore_disconnect_websocket"_a = std::nullopt)
+           "data_channel_signaling"_a = nb::none(),
+           "ignore_disconnect_websocket"_a = nb::none())
       .def("create_audio_source", &Sora::CreateAudioSource)
       .def("create_video_source", &Sora::CreateVideoSource);
 }

--- a/src/sora_sdk_ext.cpp
+++ b/src/sora_sdk_ext.cpp
@@ -203,9 +203,9 @@ NB_MODULE(sora_sdk_ext, m) {
   nb::class_<Sora>(m, "Sora")
       .def(nb::init<bool>(), "use_hardware_encoder"_a = false)
       .def("create_connection", &Sora::CreateConnection, "signaling_url"_a,
-           "role"_a, "channel_id"_a, "client_id"_a = "", "metadata"_a = nb::none(),
-           "audio_source"_a = nb::none(), "video_source"_a = nb::none(),
-           "data_channels"_a = nb::none(),
+           "role"_a, "channel_id"_a, "client_id"_a = "",
+           "metadata"_a = nb::none(), "audio_source"_a = nb::none(),
+           "video_source"_a = nb::none(), "data_channels"_a = nb::none(),
            "data_channel_signaling"_a = nb::none(),
            "ignore_disconnect_websocket"_a = nb::none())
       .def("create_audio_source", &Sora::CreateAudioSource)

--- a/src/sora_sdk_ext.cpp
+++ b/src/sora_sdk_ext.cpp
@@ -189,7 +189,8 @@ NB_MODULE(sora_sdk_ext, m) {
                              nb::type_slots(connection_slots))
       .def("connect", &SoraConnection::Connect)
       .def("disconnect", &SoraConnection::Disconnect)
-      .def("send_data_channel", &SoraConnection::SendDataChannel, "label"_a, "data"_a)
+      .def("send_data_channel", &SoraConnection::SendDataChannel, "label"_a,
+           "data"_a)
       .def_rw("on_set_offer", &SoraConnection::on_set_offer_)
       .def_rw("on_disconnect", &SoraConnection::on_disconnect_)
       .def_rw("on_notify", &SoraConnection::on_notify_)

--- a/test/messaging-recvonly.py
+++ b/test/messaging-recvonly.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
                         help="受信するデータチャネルのラベル名（複数指定可能）")
 
     # オプション引数
-    parser.add_argument("--client_id",default='',  help="クライアントID")
+    parser.add_argument("--client_id", default='',  help="クライアントID")
     parser.add_argument("--metadata", help="メタデータ JSON")
     args = parser.parse_args()
 

--- a/test/messaging-recvonly.py
+++ b/test/messaging-recvonly.py
@@ -1,3 +1,5 @@
+# Sora のデータチャネル機能を使ってメッセージを受信するサンプルスクリプト。
+# コマンドライン引数で指定されたチャネルおよびラベルに届いたメッセージを標準出力に表示する。
 import argparse
 import json
 import signal
@@ -40,11 +42,14 @@ class MessagingRecvonly:
         # シグナルを登録し、プログラムが終了するときに正常に処理が行われるようにする
         signal.signal(signal.SIGINT, self.exit_gracefully)
 
+        # Sora に接続する
         self.connection.connect()
 
+        # Ctrl+C が押されるまで待機
         while not self.shutdown:
             time.sleep(0.01)
 
+        # Sora から切断する
         self.connection.disconnect()
 
         # 切断が完了するまで待機

--- a/test/messaging-recvonly.py
+++ b/test/messaging-recvonly.py
@@ -18,7 +18,7 @@ class MessagingRecvonly:
             client_id=client_id,
             data_channels=[{"label": label, "direction": "recvonly"}
                            for label in labels],
-            data_channe_signaling=data_channel_signaling,
+            data_channel_signaling=data_channel_signaling,
             ignore_disconnect_websocket=ignore_disconnect_websocket,
             metadata=metadata,
         )

--- a/test/messaging-recvonly.py
+++ b/test/messaging-recvonly.py
@@ -1,0 +1,86 @@
+import argparse
+import json
+import signal
+import time
+
+from sora_sdk import Sora, SoraAudioSink, SoraVideoSink
+
+
+class MessagingRecvonly:
+    def __init__(self, signaling_url, channel_id, client_id,
+                 labels, data_channel_signaling, ignore_disconnect_websocket,
+                 metadata):
+        self.sora = Sora()
+        self.connection = self.sora.create_connection(
+            signaling_url=signaling_url,
+            role="recvonly",
+            channel_id=channel_id,
+            client_id=client_id,
+            data_channels=[{"label": label, "direction": "recvonly"}
+                           for label in labels],
+            data_channe_signaling=data_channel_signaling,
+            ignore_disconnect_websocket=ignore_disconnect_websocket,
+            metadata=metadata,
+        )
+
+        self.disconnected = False
+        self.connection.on_message = self.on_message
+
+    def on_disconnect(self, ec, message):
+        self.disconnected = True
+
+    def on_message(self, label, data):
+        print(f"メッセージを受信しました: label={label}, data={data}")
+
+    def exit_gracefully(self, signal_number, frame):
+        print("\nCtrl+Cが押されました。終了します")
+        self.connection.disconnect()
+        cv2.destroyAllWindows()
+        exit(0)
+
+    def run(self):
+        # シグナルを登録し、プログラムが終了するときに正常に処理が行われるようにする
+        signal.signal(signal.SIGINT, self.exit_gracefully)
+
+        self.connection.connect()
+
+        while True:
+            time.sleep(0.01)
+
+        self.connection.disconnect()
+
+        # 切断が完了するまで待機
+        while not self.disconnected:
+            time.sleep(0.01)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    # 必須引数
+    parser.add_argument("--signaling-url", required=True, help="シグナリング URL")
+    parser.add_argument("--channel-id", required=True, help="チャネルID")
+    parser.add_argument("--labels", required=True, nargs='+',
+                        help="受信するデータチャネルのラベル名（複数指定可能）")
+
+    # オプション引数
+    parser.add_argument("--client_id",default='',  help="クライアントID")
+    parser.add_argument("--metadata", help="メタデータ JSON")
+    parser.add_argument("--data-channel-signaling",
+                        action="store_true", help="データチャネルを使ったシグナリングを有効にする")
+    parser.add_argument("--ignore-disconnect-websocket",
+                        action="store_true", help="WebSocket の切断を無視する")
+    args = parser.parse_args()
+
+    metadata = None
+    if args.metadata:
+        metadata = json.loads(args.metadata)
+
+    messaging_recvonly = MessagingRecvonly(args.signaling_url,
+                                           args.channel_id,
+                                           args.client_id,
+                                           args.labels,
+                                           args.data_channel_signaling,
+                                           args.ignore_disconnect_websocket,
+                                           metadata)
+    messaging_recvonly.run()

--- a/test/messaging-recvonly.py
+++ b/test/messaging-recvonly.py
@@ -7,20 +7,18 @@ from sora_sdk import Sora, SoraAudioSink, SoraVideoSink
 
 
 class MessagingRecvonly:
-    def __init__(self, signaling_url, channel_id, client_id,
-                 labels, data_channel_signaling, ignore_disconnect_websocket,
-                 metadata):
+    def __init__(self, signaling_url, channel_id, client_id, labels, metadata):
         self.sora = Sora()
         self.connection = self.sora.create_connection(
             signaling_url=signaling_url,
             role="recvonly",
             channel_id=channel_id,
             client_id=client_id,
+            metadata=metadata,
             data_channels=[{"label": label, "direction": "recvonly"}
                            for label in labels],
-            data_channel_signaling=data_channel_signaling,
-            ignore_disconnect_websocket=ignore_disconnect_websocket,
-            metadata=metadata,
+            data_channel_signaling=True,
+            ignore_disconnect_websocket=True,
         )
 
         self.disconnected = False
@@ -66,10 +64,6 @@ if __name__ == '__main__':
     # オプション引数
     parser.add_argument("--client_id",default='',  help="クライアントID")
     parser.add_argument("--metadata", help="メタデータ JSON")
-    parser.add_argument("--data-channel-signaling",
-                        action="store_true", help="データチャネルを使ったシグナリングを有効にする")
-    parser.add_argument("--ignore-disconnect-websocket",
-                        action="store_true", help="WebSocket の切断を無視する")
     args = parser.parse_args()
 
     metadata = None
@@ -80,7 +74,5 @@ if __name__ == '__main__':
                                            args.channel_id,
                                            args.client_id,
                                            args.labels,
-                                           args.data_channel_signaling,
-                                           args.ignore_disconnect_websocket,
                                            metadata)
     messaging_recvonly.run()

--- a/test/messaging-sendonly.py
+++ b/test/messaging-sendonly.py
@@ -1,3 +1,5 @@
+# Sora のデータチャネル機能を使ってメッセージを送信するサンプルスクリプト。
+# コマンドライン引数で指定されたチャネルおよびラベルに、同じくコマンドライン引数で指定されたデータを送信する。
 import argparse
 import json
 import time
@@ -35,6 +37,7 @@ class MessagingSendonly:
         self.connection.connect()
 
     def send(self, data):
+        # on_data_channel() が呼ばれるまではデータチャネルの準備ができていないので待機
         while not self.is_data_channel_ready:
             time.sleep(0.01)
 

--- a/test/messaging-sendonly.py
+++ b/test/messaging-sendonly.py
@@ -57,9 +57,8 @@ if __name__ == '__main__':
     parser.add_argument("--label", required=True, help="送信するデータチャネルのラベル名")
     parser.add_argument("--data", required=True, help="送信するデータ")
 
-
     # オプション引数
-    parser.add_argument("--client_id",default='',  help="クライアントID")
+    parser.add_argument("--client_id", default='',  help="クライアントID")
     parser.add_argument("--metadata", help="メタデータ JSON")
     args = parser.parse_args()
 

--- a/test/messaging-sendonly.py
+++ b/test/messaging-sendonly.py
@@ -73,5 +73,5 @@ if __name__ == '__main__':
                                            args.label,
                                            metadata)
     messaging_sendonly.connect()
-    messaging_sendonly.send(args.data)
+    messaging_sendonly.send(args.data.encode("utf-8"))
     messaging_sendonly.disconnect()

--- a/test/messaging-sendrecv.py
+++ b/test/messaging-sendrecv.py
@@ -6,22 +6,24 @@ import time
 from sora_sdk import Sora
 
 
-class MessagingRecvonly:
-    def __init__(self, signaling_url, channel_id, client_id, labels, metadata):
+class MessagingSendrecv:
+    def __init__(self, signaling_url, channel_id, client_id, data_channels, metadata):
         self.sora = Sora()
         self.connection = self.sora.create_connection(
             signaling_url=signaling_url,
-            role="recvonly",
+            role="sendrecv",
             channel_id=channel_id,
             client_id=client_id,
             metadata=metadata,
-            data_channels=[{"label": label, "direction": "recvonly"}
-                           for label in labels],
+            data_channels=data_channels,
             data_channel_signaling=True,
         )
 
+        self.data_channels = data_channels
         self.disconnected = False
         self.shutdown = False
+        self.sendable_data_channels = set()
+        self.connection.on_data_channel = self.on_data_channel
         self.connection.on_message = self.on_message
         self.connection.on_disconnect = self.on_disconnect
 
@@ -30,6 +32,15 @@ class MessagingRecvonly:
 
     def on_message(self, label, data):
         print(f"メッセージを受信しました: label={label}, data={data}")
+
+    def on_data_channel(self, label):
+        for data_channel in self.data_channels:
+            if data_channel["label"] != label:
+                continue
+
+            if data_channel["direction"] == "sendrecv" or data_channel["direction"] == "sendonly":
+                self.sendable_data_channels.add(label)
+                break
 
     def exit_gracefully(self, signal_number, frame):
         print("\nCtrl+Cが押されました。終了します")
@@ -42,8 +53,16 @@ class MessagingRecvonly:
 
         self.connection.connect()
 
+        i = 0
         while not self.shutdown:
+            if i % 100 == 0:
+                for label in self.sendable_data_channels:
+                    data = f"No. {i / 100}".encode("utf-8")
+                    print(f"メッセージを送信します: label={label}, data={data}")
+                    self.connection.send_data_channel(label, data)
+
             time.sleep(0.01)
+            i += 1
 
         self.connection.disconnect()
 
@@ -58,8 +77,8 @@ if __name__ == '__main__':
     # 必須引数
     parser.add_argument("--signaling-url", required=True, help="シグナリング URL")
     parser.add_argument("--channel-id", required=True, help="チャネルID")
-    parser.add_argument("--labels", required=True, nargs='+',
-                        help="受信するデータチャネルのラベル名（複数指定可能）")
+    parser.add_argument("--data-channels", required=True,
+                        help="使用するデータチャネルを JSON で指定する (例: '[{\"label\": \"#spam\", \"direction\": \"sendrecv\"}]')")
 
     # オプション引数
     parser.add_argument("--client_id",default='',  help="クライアントID")
@@ -70,9 +89,9 @@ if __name__ == '__main__':
     if args.metadata:
         metadata = json.loads(args.metadata)
 
-    messaging_recvonly = MessagingRecvonly(args.signaling_url,
+    messaging_sendrecv = MessagingSendrecv(args.signaling_url,
                                            args.channel_id,
                                            args.client_id,
-                                           args.labels,
+                                           json.loads(args.data_channels),
                                            metadata)
-    messaging_recvonly.run()
+    messaging_sendrecv.run()

--- a/test/messaging-sendrecv.py
+++ b/test/messaging-sendrecv.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
                         help="使用するデータチャネルを JSON で指定する (例: '[{\"label\": \"#spam\", \"direction\": \"sendrecv\"}]')")
 
     # オプション引数
-    parser.add_argument("--client_id",default='',  help="クライアントID")
+    parser.add_argument("--client_id", default='',  help="クライアントID")
     parser.add_argument("--metadata", help="メタデータ JSON")
     args = parser.parse_args()
 


### PR DESCRIPTION
タイトルの通り Python SDK から Sora のデータチャネルを使ったメッセージの送受信を行えるようにします。
詳しい変更内容は CHANGES.md を参照してください。

### PR の対象外

以下は別の PR で対応予定です:
- データチャネルだけを使う場合に映像や音声を OFF にできるようにする
- 開発用に test/*.py 以下のスクリプトを簡単に実行できるようにする
  - 今は以下の手順が必要になります
     1. pyproject.toml の `build-system.requires` の中身を `tool.rye.dev-dependencies` の末尾に追加する
     2. `rye sync` を実行
     3. `rye run python setup.py build` を実行
         - この時に `_skbuild/` ディレクトリが既に存在するとビルドに失敗することがあるので、必要なら削除する
     4. `PYTHONPATH=_skbuild/macosx-13.0-arm64-3.8/setuptools/lib.macosx-13.0-arm64-cpython-38/ rye run python3 test/messaging-sendrecv.py` の用に PYTHONPATH 環境変数でビルド後のディレクトリが存在するパスを指定してサンプルスクリプトを実行する
          - 具体的なパスは OS やビルド環境によって変わるので注意
