### PR TITLE
転送フィルターのルールの "operator" フィールドが誤って "op" になっていたのを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [FIX] 転送フィルターのルールの "operator" フィールドが誤って "op" になっていたのを修正する
+  - @sile
 - [UPDATE] nanobind の最小バージョンを 1.4.0 にする
   - @voluntas
 - [UPDATE] sora_client に "Sora Python SDK {PYTHON_SDK_VERSION}" を設定する

--- a/src/sora.cpp
+++ b/src/sora.cpp
@@ -260,7 +260,7 @@ Sora::ConvertForwardingFilter(const nb::handle value) {
         auto and_rule = and_rule_value.as_object();
         sora::SoraSignalingConfig::ForwardingFilter::Rule rule;
         rule.field = and_rule["field"].as_string();
-        rule.op = and_rule["op"].as_string();
+        rule.op = and_rule["operator"].as_string();
         for (auto value : and_rule["values"].as_array()) {
           rule.values.push_back(value.as_string().c_str());
         }


### PR DESCRIPTION
自明なタイポ修正なので CI が通ったらマージします