### PR TITLE
VAD の追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [ADD] 発話区間の検出が可能な SoraVAD の追加
+  - @tnoho
 - [ADD] リアルタイム性を重視した AudioStreamSink の追加
   - @tnoho
 - [ADD] AudioStreamSink が返す音声フレームとして pickel が可能な AudioFrame を追加

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ nanobind_add_module(
   src/sora_factory.cpp
   src/sora_log.cpp
   src/sora_sdk_ext.cpp
+  src/sora_vad.cpp
   src/sora_video_sink.cpp
   src/sora_video_source.cpp
 )

--- a/src/sora_sdk_ext.cpp
+++ b/src/sora_sdk_ext.cpp
@@ -15,6 +15,7 @@
 #include "sora_connection.h"
 #include "sora_log.h"
 #include "sora_track_interface.h"
+#include "sora_vad.h"
 #include "sora_video_sink.h"
 #include "sora_video_source.h"
 
@@ -249,6 +250,10 @@ NB_MODULE(sora_sdk_ext, m) {
            "output_frequency"_a = -1, "output_channels"_a = 0)
       .def("__del__", &SoraAudioStreamSinkImpl::Del)
       .def_rw("on_frame", &SoraAudioStreamSinkImpl::on_frame_);
+
+  nb::class_<SoraVAD>(m, "SoraVAD")
+      .def(nb::init<>())
+      .def("analyze", &SoraVAD::Analyze);
 
   nb::class_<SoraVideoFrame>(m, "SoraVideoFrame")
       .def("data", &SoraVideoFrame::Data, nb::rv_policy::reference);

--- a/src/sora_vad.cpp
+++ b/src/sora_vad.cpp
@@ -1,0 +1,42 @@
+#include "sora_vad.h"
+
+#include <chrono>
+
+// WebRTC
+#include <api/audio/channel_layout.h>
+#include <modules/audio_mixer/audio_frame_manipulator.h>
+#include <modules/audio_processing/agc2/agc2_common.h>
+#include <modules/audio_processing/agc2/cpu_features.h>
+#include <modules/audio_processing/agc2/rnn_vad/common.h>
+#include <modules/audio_processing/include/audio_frame_view.h>
+
+SoraVAD::SoraVAD() {
+  vad_ = std::make_unique<webrtc::VoiceActivityDetectorWrapper>(
+      webrtc::kVadResetPeriodMs,  // libWebRTC 内部の設定に合わせる
+      webrtc::GetAvailableCpuFeatures(),
+      webrtc::rnn_vad::
+          kSampleRate24kHz  // 24kHz にしておかないと、VAD 前にリサンプリングが走る
+  );
+}
+
+float SoraVAD::Analyze(std::shared_ptr<SoraAudioFrame> frame) {
+  if (!audio_buffer_ ||
+      vad_input_config_.sample_rate_hz() != frame->sample_rate_hz() ||
+      vad_input_config_.num_channels() != frame->num_channels()) {
+    // audio_buffer_ のサンプリングレートやチャネル数と frame のそれが一致しない場合は audio_buffer_ を初期化する
+    audio_buffer_.reset(new webrtc::AudioBuffer(
+        frame->sample_rate_hz(), frame->num_channels(),
+        webrtc::rnn_vad::kSampleRate24kHz,  // VAD は 24kHz なので合わせる
+        1,  // VAD は 1 チャンネルなので合わせる
+        webrtc::rnn_vad::
+            kSampleRate24kHz,  // 出力はしないが、余計なインスタンスを生成しないよう合わせる
+        1  // 出力はしないが VAD とチャネル数は合わせておく
+        ));
+    vad_input_config_ =
+        webrtc::StreamConfig(frame->sample_rate_hz(), frame->num_channels());
+  }
+  audio_buffer_->CopyFrom(frame->RawData(), vad_input_config_);
+  return vad_->Analyze(webrtc::AudioFrameView<const float>(
+      audio_buffer_->channels(), audio_buffer_->num_channels(),
+      audio_buffer_->num_frames()));
+}

--- a/src/sora_vad.h
+++ b/src/sora_vad.h
@@ -1,0 +1,46 @@
+#ifndef SORA_VAD_H_
+#define SORA_VAD_H_
+
+// nonobind
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+// WebRTC
+#include <common_audio/vad/include/webrtc_vad.h>
+#include <modules/audio_processing/agc2/vad_wrapper.h>
+#include <modules/audio_processing/audio_buffer.h>
+#include <modules/audio_processing/include/audio_processing.h>
+
+#include "sora_audio_sink2.h"
+
+namespace nb = nanobind;
+
+/**
+ * SoraAudioFrame の音声データに音声である率を返す VAD です。
+ * 
+ * 受信した音声データに対して何らかの処理を Python で行う場合、
+ * 全体の負荷軽減を考えるのであれば音声データから音声であると推測されるデータのみに、
+ * 処理を行うようにした方が全体の負荷を下げることができます。
+ * libwebrtc には優秀な VAD が含まれているため、これを活用したユーティリティクラスとして用意しました。
+ */
+class SoraVAD {
+ public:
+  SoraVAD();
+
+  /**
+   * SoraAudioFrame 内の音声データが音声である確率を返します。
+   * 
+   * libwebrtc 内部では 0.95 より大きい場合に音声とみなしています。
+   * 
+   * @param frame 音声である確率を求める SoraAudioFrame
+   * @return 0 - 1 で表される音声である確率
+   */
+  float Analyze(std::shared_ptr<SoraAudioFrame> frame);
+
+ private:
+  std::unique_ptr<webrtc::AudioBuffer> audio_buffer_;
+  webrtc::StreamConfig vad_input_config_;
+  std::unique_ptr<webrtc::VoiceActivityDetectorWrapper> vad_;
+};
+
+#endif

--- a/src/sora_vad.h
+++ b/src/sora_vad.h
@@ -11,7 +11,7 @@
 #include <modules/audio_processing/audio_buffer.h>
 #include <modules/audio_processing/include/audio_processing.h>
 
-#include "sora_audio_sink2.h"
+#include "sora_audio_stream_sink.h"
 
 namespace nb = nanobind;
 


### PR DESCRIPTION
SoraAudioFrame の音声データが音声である率を返す VAD を追加したいと思います。

受信した音声データに対して何らかの処理を Python で行う場合、負荷軽減を考えるのであれば音声データから音声であると推測されるデータのみに、処理を行うようにした方が負荷を下げることができます。

libwebrtc には優秀な VAD が含まれているため、これを活用したユーティリティクラスとして用意しました。

非常に少ないコードで実現できているのでメンテコストも低いかと思います。ぜひ取り込んでいただければ幸いです🙏