### PR TITLE
ForwardingFilter に version と metadata を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@
   - @tnoho
 - [ADD] AudioStreamSink が返す音声フレームとして pickel が可能な AudioFrame を追加
   - @tnoho
-- [UPDATE] Sora C++ SDK のバージョンを 2023.17.0 に上げる
+- [UPDATE] Sora C++ SDK のバージョンを 2024.1.0 に上げる
   - WebRTC m116 で cricket::Codec は protected になったので cricket::CreateVideoCodec に修正する
   - WebRTC m118 でパッケージディレクトリが変更されたためそれに追従する
   - WebRTC m120 の webrtc::EncodedImage API の変更に追従する
@@ -33,6 +33,9 @@
   - BOOST_VERSION を `1.83.0` に上げる
   - CMAKE_VERSION を `3.27.7` に上げる
   - @voluntas @miosakuma
+- [UPDATE] ForwardingFilter に version と metadata を追加する
+  - Sora 2023.2.0, C++ SDK 2024.1.0 への追従
+  - @miosakuma
 
 ## 2023.3.1
 

--- a/src/sora.cpp
+++ b/src/sora.cpp
@@ -286,6 +286,12 @@ Sora::ConvertForwardingFilter(const nb::handle value) {
       }
       filter.rules.push_back(rules);
     }
+    if (!object["version"].is_null()) {
+      filter.version = std::string(object["version"].as_string());
+    }
+    if (!object["metadata"].is_null()) {
+      filter.metadata = object["metadata"];
+    }
   } catch (std::exception&) {
     throw nb::type_error("Invalid forwarding_filter");
   }


### PR DESCRIPTION
Sora 2023.2.0 の追従で version と metadta を追加しています。

以下の動作確認を行っています。

version
- 設定したとき、connect に値の送信が行われること
- 未設定の時、値の送信が行われないこと
- 文字列でない時に実行エラーとなること

metadata
- "metadata": "abc" を設定したとき、connect に値の送信が行われること
- "metadata": {"spam":"egg"} を設定したとき、connect に値の送信が行われること
- 未設定の時、値の送信が行われないこと
- JSON 文字列でない時に実行エラーとなること

tests/test_recvonly.py のソースを改変することでテストを行っています

```
def test_sendonly():
    sora = Sora()

    str_forwarding_filter = """
    {
        "version": "client",
        "metadata": {"spam": "egg", "foo": {"bar": "baz"}},
        "rules": [
            [
                {"field": "kind", "operator": "is_in", "values": ["video"]}
            ]
        ]
    }
    """

    conn = sora.create_connection(
        signaling_urls= ["wss://sora.fine-clue.com/signaling"],
        role="recvonly",
        channel_id="sora",
        forwarding_filter = json.loads(str_forwarding_filter)
    )
```
