### PR TITLE
JetPack を 5.1.2 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,8 @@
   - BOOST_VERSION を `1.83.0` に上げる
   - CMAKE_VERSION を `3.27.7` に上げる
   - @voluntas @miosakuma
+- [UPDATE] JetPack を 5.1.2 に上げる
+  - @miosakuma
 
 ## 2023.3.1
 

--- a/multistrap/ubuntu-20.04_armv8_jetson.conf
+++ b/multistrap/ubuntu-20.04_armv8_jetson.conf
@@ -13,11 +13,11 @@ components=main universe
 [Jetson]
 packages=
 source=https://repo.download.nvidia.com/jetson/common
-suite=r35.2
+suite=r35.4
 components=main
 
 [T194]
 packages=nvidia-l4t-camera nvidia-l4t-jetson-multimedia-api
 source=https://repo.download.nvidia.com/jetson/t194
-suite=r35.2
+suite=r35.4
 components=main


### PR DESCRIPTION
JetPack 5.1 以前は動作がしなくなります。