### PR TITLE
Windows のビルドが通らないので、 windows-2019 に戻す

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
           path: "dist/"
 
   build_windows:
-    runs-on: windows-2022
+    runs-on: windows-2019
     timeout-minutes: 60
     strategy:
       fail-fast: false


### PR DESCRIPTION
## 変更内容

windows-2022 でビルドが失敗するので windows-2019 に戻しました

## メモ

- 同様のエラーが報告された GitHub のイシューは既にクローズされたが、なぜか Sora Python SDK のビルドは改善しなかった https://github.com/actions/runner-images/issues/9399
- webrtc-build にパッチして windows-2022 のビルドを通した事例はあるが、 webrtc-build にパッチしてリリースする必要があるため対応に時間がかかる https://github.com/shiguredo-webrtc-build/webrtc-build/blob/m120.6099.1.2-hololens2.2/winuwp/008-streamer.patch