### PR TITLE
on_switched を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
   - audio_codec_lyra_usedtx
   - check_lyra_version
   - @enm10k
+- [ADD] `on_switched` コールバックを追加する
+  - @enm10k
 - [UPDATE] nanobind を `1.9.2` に上げて固定する
   - @voluntas
 - [UPDATE] ruff の最小を ``0.3.0` に上げる

--- a/src/sora_connection.cpp
+++ b/src/sora_connection.cpp
@@ -157,6 +157,12 @@ void SoraConnection::OnMessage(std::string label, std::string data) {
   }
 }
 
+void SoraConnection::OnSwitched(std::string text) {
+  if (on_switched_) {
+    on_switched_(text);
+  }
+}
+
 void SoraConnection::OnTrack(
     rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver) {
   if (on_track_) {

--- a/src/sora_connection.h
+++ b/src/sora_connection.h
@@ -93,6 +93,7 @@ class SoraConnection : public sora::SoraSignalingObserver,
   void OnNotify(std::string text) override;
   void OnPush(std::string text) override;
   void OnMessage(std::string label, std::string data) override;
+  void OnSwitched(std::string text) override;
   void OnTrack(
       rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver) override;
   void OnRemoveTrack(
@@ -105,6 +106,7 @@ class SoraConnection : public sora::SoraSignalingObserver,
   std::function<void(std::string)> on_notify_;
   std::function<void(std::string)> on_push_;
   std::function<void(std::string, nb::bytes)> on_message_;
+  std::function<void(std::string)> on_switched_;
   std::function<void(std::shared_ptr<SoraMediaTrack>)> on_track_;
   std::function<void(std::string)> on_data_channel_;
 

--- a/src/sora_sdk_ext.cpp
+++ b/src/sora_sdk_ext.cpp
@@ -118,6 +118,11 @@ int connection_tp_traverse(PyObject* self, visitproc visit, void* arg) {
     Py_VISIT(on_message.ptr());
   }
 
+  if (conn->on_switched_) {
+    nb::object on_switched = nb::cast(conn->on_switched_, nb::rv_policy::none);
+    Py_VISIT(on_switched.ptr());
+  }
+
   if (conn->on_track_) {
     nb::object on_track = nb::cast(conn->on_track_, nb::rv_policy::none);
     Py_VISIT(on_track.ptr());
@@ -286,6 +291,7 @@ NB_MODULE(sora_sdk_ext, m) {
       .def_rw("on_notify", &SoraConnection::on_notify_)
       .def_rw("on_push", &SoraConnection::on_push_)
       .def_rw("on_message", &SoraConnection::on_message_)
+      .def_rw("on_switched", &SoraConnection::on_switched_)
       .def_rw("on_track", &SoraConnection::on_track_)
       .def_rw("on_data_channel", &SoraConnection::on_data_channel_);
 


### PR DESCRIPTION
## 変更内容

on_switched を追加しました。
type: switched を受信した際に呼ばれるコールバックです。

### メモ: 動作確認

on_switched.py

```
import json
import time

from sora_sdk import Sora


def on_switched(message: str):
    print(f'on_switchd: {message}')


if __name__ == "__main__":
    sora = Sora()
    conn = sora.create_connection(
        signaling_urls=["wss://example.co.jp/signaling"],
        role="sendonly",
        channel_id="hoge ",
    )
    # コールバックを登録する
    conn.on_switched = on_switched

    conn.connect()

    time.sleep(10)
...
```

```
# ビルド
rye sync
rye run python run.py

# 実行
rye run python ../path/to/on_switched.py
on_switchd: {"type":"switched","ignore_disconnect_websocket":false}
...
```