### PR TITLE
SoraAudioSink.read が timeout を無視して失敗を返すケースがあったので修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - [UPDATE] Sora C++ SDK のバージョンを `2024.6.1` に上げる
   - @voluntas
+- [FIX] SoraAudioSink.read が timeout を無視して失敗を返すケースがあったので修正する
+  - @enm10k
 
 ## 2024.2.0
 

--- a/src/sora_audio_sink.cpp
+++ b/src/sora_audio_sink.cpp
@@ -134,10 +134,6 @@ void SoraAudioSinkImpl::AppendData(const int16_t* audio_data,
 nb::tuple SoraAudioSinkImpl::Read(size_t frames, float timeout) {
   std::unique_lock<std::mutex> lock(buffer_mtx_);
 
-  if (buffer_.size() == 0) {
-    // 返すものがない時は即座に返す
-    return nb::make_tuple(false, nb::none());
-  }
   size_t num_of_samples;
   if (frames > 0) {
     // フレーム数のリクエストがある場合はリクエスト分が貯まるまで待つ
@@ -160,6 +156,9 @@ nb::tuple SoraAudioSinkImpl::Read(size_t frames, float timeout) {
     }
   } else {
     // フレーム数のリクエストがない場合はあるだけ全部出す
+    if (buffer_.empty()) {
+      return nb::make_tuple(false, nb::none());
+    }
     num_of_samples = buffer_.size();
   }
 


### PR DESCRIPTION
## 背景

修正前は `SoraAudioSinkImpl::Read` の先頭でバッファーのサイズをチェックし、バッファーが空の場合失敗を返すようになっていました。

上記のチェックは、引数に `frames=0` を指定して、 `SoraAudioSinkImpl::Read` 実行時にバッファーに保持されている全てのデータを取得する場合には必要なものです。
しかし、 `frames=5, timeout=1` などと指定して `SoraAudioSinkImpl::Read` を実行した場合、そのタイミングでバッファーが空なら timeout を無視して即座に失敗を返してしまうという実装になっていました。

## 参照

- ドキュメントの該当箇所 https://sora-python-sdk.shiguredo.jp/sora_sdk#3af3d1