### PR TITLE
#64 の修正後、  SoraAudioSink.read() の実行タイミングによってはクラッシュが発生するようになった問題の対応

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
   - @voluntas
 - [FIX] SoraAudioSink.read が timeout を無視して失敗を返すケースがあったので修正する
   - @enm10k
+- [FIX] SoraAudioSink.read が timeout を無視するケースがある問題を修正した結果、 read の実行タイミングによってはクラッシュするようになったので修正する
+  - @enm10k
 
 ## 2024.2.0
 


### PR DESCRIPTION
## 変更内容

https://github.com/shiguredo/sora-python-sdk/pull/64 の修正後に、 SoraAudioSink.read() の実行タイミングによってクラッシュが発生するようになりました

num_of_samples　を計算する位置と、 std::condition_variable::wait_for の完了条件を修正して、問題のクラッシュが発生しないようになることを確認しました

## 再現コード

```python
import faulthandler
import time
import numpy
import sora_sdk

faulthandler.enable()

def on_track(track):
    if track.kind == "audio":
        # 実際に出力することはないので frequery と channels は適当に設定する
        output_frequency = 16000
        output_channels = 1
        audio_sink = sora_sdk.SoraAudioSink(track, output_frequency, output_channels)

        # ここで floating point exception が発生する (Ubuntu)
        # OS によって発生するエラー内容が異なる
        print(audio_sink.read(1, 1))

def test_repro_floating_point_exception():
    SIGNALING_URL = "wss://example.com/signaling"
    CHANNEL_ID = "repro_floating_point_exception"

    sora = sora_sdk.Sora()

    send_conn = sora.create_connection(
        signaling_urls=[SIGNALING_URL],
        role="sendonly",
        channel_id=CHANNEL_ID,
        video=False,
    )

    recv_conn = sora.create_connection(
        signaling_urls=[SIGNALING_URL],
        role="recvonly",
        channel_id=CHANNEL_ID,
        video=False,
    )
    recv_conn.on_track = on_track

    try:
        send_conn.connect()
        recv_conn.connect()

        time.sleep(5)
    finally:
        send_conn.disconnect()
        recv_conn.disconnect()

test_repro_floating_point_exception()
```

---

This pull request primarily addresses a bug in the `SoraAudioSink.read` function in the `src/sora_audio_sink.cpp` file, as well as updates the `CHANGES.md` file to reflect these changes. The bug fix ensures that the function does not ignore timeouts and prevents crashes depending on the timing of the read operation. 

Bug fix in `SoraAudioSink.read`:

* [`src/sora_audio_sink.cpp`](diffhunk://#diff-49bfe0a75e9af7f5922b260b469949727ffd57f5f034e46ec57b293dde1249b7L140-R147): In the `SoraAudioSinkImpl::Read` function, the calculation of `num_of_samples` has been moved to after the conditional wait to account for possible updates to `number_of_channels_` during the wait. The condition for the wait has also been updated to check that `number_of_channels_` is greater than 0 before comparing the buffer size with the number of samples. [[1]](diffhunk://#diff-49bfe0a75e9af7f5922b260b469949727ffd57f5f034e46ec57b293dde1249b7L140-R147) [[2]](diffhunk://#diff-49bfe0a75e9af7f5922b260b469949727ffd57f5f034e46ec57b293dde1249b7R157-R159)

Updates to `CHANGES.md`:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R18-R19): The fix description for `SoraAudioSink.read` has been updated to reflect the changes made to address the bug.