### PR TITLE
sora_sdk に型を付ける

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ build
 src/sora_sdk/*.so
 src/sora_sdk/*.dll
 src/sora_sdk/*.pyd
+src/sora_sdk/*.pyi
+src/sora_sdk/py.typed
 
 # パッケージ
 /dist

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
   - @melpon
 - [UPDATE] Sora C++ SDK のバージョンを `2024.6.1` に上げる
   - @voluntas
+- [ADD] sora_sdk に型を付ける
+  - @melpon
 - [FIX] SoraAudioSink.read が timeout を無視して失敗を返すケースがあったので修正する
   - @enm10k
 - [FIX] SoraAudioSink.read が timeout を無視するケースがある問題を修正した結果、 read の実行タイミングによってはクラッシュするようになったので修正する

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,15 @@ nanobind_add_module(
   src/sora_video_source.cpp
 )
 
+nanobind_add_stub(
+  sora_sdk_ext_stub
+  MODULE sora_sdk_ext
+  OUTPUT sora_sdk_ext.pyi
+  PYTHON_PATH $<TARGET_FILE_DIR:sora_sdk_ext>
+  DEPENDS sora_sdk_ext
+  MARKER_FILE py.typed
+)
+
 set_target_properties(sora_sdk_ext PROPERTIES CXX_STANDARD 20 C_STANDARD 20)
 set_target_properties(sora_sdk_ext PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
@@ -132,3 +141,4 @@ endif()
 target_link_libraries(sora_sdk_ext PRIVATE Sora::sora)
 
 install(TARGETS sora_sdk_ext LIBRARY DESTINATION .)
+install(FILES py.typed sora_sdk_ext.pyi DESTINATION ".")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev-dependencies = [
     "auditwheel~=6.0.0",
     "pytest>=8.2",
     "ruff>=0.4",
+    "typing-extensions>=4.12.2",
 ]
 
 [tool.ruff]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -34,6 +34,7 @@ setuptools==70.0.0
 tomli==2.0.1
     # via build
     # via pytest
+typing-extensions==4.12.2
 wheel==0.43.0
 zipp==3.19.0
     # via importlib-metadata

--- a/run.py
+++ b/run.py
@@ -779,6 +779,10 @@ def main():
                 shutil.copyfile(
                     os.path.join(sora_build_target_dir, file), os.path.join(sora_src_dir, file)
                 )
+            if file in ("sora_sdk_ext.pyi", "py.typed"):
+                shutil.copyfile(
+                    os.path.join(sora_build_target_dir, file), os.path.join(sora_src_dir, file)
+                )
 
 
 if __name__ == "__main__":

--- a/src/sora_sdk_ext.cpp
+++ b/src/sora_sdk_ext.cpp
@@ -319,7 +319,50 @@ NB_MODULE(sora_sdk_ext, m) {
            "insecure"_a = nb::none(), "client_cert"_a = nb::none(),
            "client_key"_a = nb::none(), "proxy_url"_a = nb::none(),
            "proxy_username"_a = nb::none(), "proxy_password"_a = nb::none(),
-           "proxy_agent"_a = nb::none())
+           "proxy_agent"_a = nb::none(),
+           nb::sig("def create_connection("
+                   "self, "
+                   "signaling_urls: list[str], "
+                   "role: str, "
+                   "channel_id: str, "
+                   "client_id: Optional[str] = None, "
+                   "bundle_id: Optional[str] = None, "
+                   "metadata: Optional[dict] = None, "
+                   "signaling_notify_metadata: Optional[dict] = None, "
+                   "audio_source: Optional[SoraTrackInterface] = None, "
+                   "video_source: Optional[SoraTrackInterface] = None, "
+                   "audio: Optional[bool] = None, "
+                   "video: Optional[bool] = None, "
+                   "audio_codec_type: Optional[str] = None, "
+                   "video_codec_type: Optional[str] = None, "
+                   "video_bit_rate: Optional[int] = None, "
+                   "audio_bit_rate: Optional[int] = None, "
+                   "video_vp9_params: Optional[dict] = None, "
+                   "video_av1_params: Optional[dict] = None, "
+                   "video_h264_params: Optional[dict] = None, "
+                   "simulcast: Optional[bool] = None, "
+                   "spotlight: Optional[bool] = None, "
+                   "spotlight_number: Optional[int] = None, "
+                   "simulcast_rid: Optional[str] = None, "
+                   "spotlight_focus_rid: Optional[str] = None, "
+                   "spotlight_unfocus_rid: Optional[str] = None, "
+                   "forwarding_filter: Optional[dict] = None, "
+                   "data_channels: Optional[list[dict]] = None, "
+                   "data_channel_signaling: Optional[bool] = None, "
+                   "ignore_disconnect_websocket: Optional[bool] = None, "
+                   "data_channel_signaling_timeout: Optional[int] = None, "
+                   "disconnect_wait_timeout: Optional[int] = None, "
+                   "websocket_close_timeout: Optional[int] = None, "
+                   "websocket_connection_timeout: Optional[int] = None, "
+                   "audio_streaming_language_code: Optional[str] = None, "
+                   "insecure: Optional[bool] = None, "
+                   "client_cert: Optional[str] = None, "
+                   "client_key: Optional[str] = None, "
+                   "proxy_url: Optional[str] = None, "
+                   "proxy_username: Optional[str] = None, "
+                   "proxy_password: Optional[str] = None, "
+                   "proxy_agent: Optional[str] = None"
+                   ") -> SoraConnection"))
       .def("create_audio_source", &Sora::CreateAudioSource, "channels"_a,
            "sample_rate"_a)
       .def("create_video_source", &Sora::CreateVideoSource);


### PR DESCRIPTION
VSCode で補間が効くようになりました。

![image](https://github.com/shiguredo/sora-python-sdk/assets/816539/42d73a66-c819-4516-a676-8ccfea33f4cc)
