### PR TITLE
Windows の nanobind のビルドが通らないのを修正する

### DIFF
--- a/fix_nanobind_nb_func.patch
+++ b/fix_nanobind_nb_func.patch
@@ -1,0 +1,35 @@
+# https://github.com/wjakob/nanobind/issues/613 の問題を修正するパッチ
+# 以下のように利用する
+#
+# ```
+# cp include/nanobind/nb_func.h include/nanobind/nb_func.h.old
+# patch < fix_nanobind_nf_func.patch
+# ```
+#
+--- include/nanobind/nb_func.h.old	2024-07-19 07:55:35.166432900 +0900
++++ include/nanobind/nb_func.h	2024-07-19 07:50:33.812445300 +0900
+@@ -199,14 +199,24 @@
+ 
+         PyObject *result;
+         if constexpr (std::is_void_v<Return>) {
++#if defined(_WIN32)
++            cap->func(static_cast<cast_t<Args>>(in.template get<Is>())...);
++#else
+             cap->func(in.template get<Is>().operator cast_t<Args>()...);
++#endif
+             result = Py_None;
+             Py_INCREF(result);
+         } else {
++#if defined(_WIN32)
++            result = cast_out::from_cpp(
++                       cap->func(static_cast<cast_t<Args>>(in.template get<Is>())...),
++                       policy, cleanup).ptr();
++#else
+             result = cast_out::from_cpp(
+                        cap->func((in.template get<Is>())
+                                      .operator cast_t<Args>()...),
+                        policy, cleanup).ptr();
++#endif
+         }
+ 
+         if constexpr (Info::keep_alive)


### PR DESCRIPTION
https://github.com/wjakob/nanobind/issues/613 の問題を修正するパッチです。
MSVC から新しいバージョンのコンパイラが出て、GitHub Actions に適用されれば不要になるはず。
