### PR TITLE
on_ws_close コールバックを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
   - @tnoho
 - [ADD] Ubuntu 24.04 armv8 に対応する
   - @melpon
+- [ADD] `on_ws_close` コールバックを追加する
+  - @tnoho
 - [UPDATE] Sora C++ SDK のバージョンを `2024.8.0` に上げる
   - WEBRTC_BUILD_VERSION を `m128.6613.2.0` に上げる
     - libwebrtc のモジュール分割に追従するため rtc::CreateRandomString のヘッダを追加

--- a/src/sora_connection.cpp
+++ b/src/sora_connection.cpp
@@ -197,6 +197,12 @@ void SoraConnection::OnSignalingMessage(sora::SoraSignalingType type,
   }
 }
 
+void SoraConnection::OnWsClose(uint16_t code, std::string message) {
+  if (on_ws_close_) {
+    on_ws_close_(code, message);
+  }
+}
+
 void SoraConnection::OnTrack(
     rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver) {
   if (on_track_) {

--- a/src/sora_connection.h
+++ b/src/sora_connection.h
@@ -105,6 +105,7 @@ class SoraConnection : public sora::SoraSignalingObserver,
   void OnSignalingMessage(sora::SoraSignalingType type,
                           sora::SoraSignalingDirection direction,
                           std::string message) override;
+  void OnWsClose(uint16_t code, std::string message);
   void OnTrack(
       rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver) override;
   void OnRemoveTrack(
@@ -116,6 +117,7 @@ class SoraConnection : public sora::SoraSignalingObserver,
       void(sora::SoraSignalingType, sora::SoraSignalingDirection, std::string)>
       on_signaling_message_;
   std::function<void(std::string)> on_set_offer_;
+  std::function<void(int, std::string)> on_ws_close_;
   std::function<void(sora::SoraSignalingErrorCode, std::string)> on_disconnect_;
   std::function<void(std::string)> on_notify_;
   std::function<void(std::string)> on_push_;

--- a/src/sora_sdk_ext.cpp
+++ b/src/sora_sdk_ext.cpp
@@ -97,6 +97,11 @@ int connection_tp_traverse(PyObject* self, visitproc visit, void* arg) {
     Py_VISIT(on_set_offer.ptr());
   }
 
+  if (conn->on_ws_close_) {
+    nb::object on_ws_close = nb::cast(conn->on_ws_close_, nb::rv_policy::none);
+    Py_VISIT(on_ws_close.ptr());
+  }
+
   if (conn->on_disconnect_) {
     nb::object on_disconnect =
         nb::cast(conn->on_disconnect_, nb::rv_policy::none);
@@ -301,6 +306,7 @@ NB_MODULE(sora_sdk_ext, m) {
            "data"_a)
       .def("get_stats", &SoraConnection::GetStats)
       .def_rw("on_set_offer", &SoraConnection::on_set_offer_)
+      .def_rw("on_ws_close", &SoraConnection::on_ws_close_)
       .def_rw("on_disconnect", &SoraConnection::on_disconnect_)
       .def_rw("on_signaling_message", &SoraConnection::on_signaling_message_)
       .def_rw("on_notify", &SoraConnection::on_notify_)


### PR DESCRIPTION
https://github.com/shiguredo/sora-cpp-sdk/pull/130 と連動します。
WebSocket が閉じられた時の code と reason を取得できるよう OnWsClose を SoraSignalingObserver に追加します。