### PR TITLE
macos-15 追加

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         python_version: ["3.10", "3.11", "3.12"]
         # macos-13 は test_macos.py が上手くテストが動かないのでスキップ
-        os: ["macos-14"]
+        os: ["macos-14", "macos-15"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     if: >-


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/e2e-test.yml` file to enhance the end-to-end testing matrix.

Testing matrix update:

* [`.github/workflows/e2e-test.yml`](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2L54-R54): Added `macos-15` to the list of operating systems for the testing matrix.