### PR TITLE
Sora CPP SDK の 2024.8.0-canary.26 の変更に対応

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,8 @@
 - [UPDATE] Sora C++ SDK のバージョンを `2024.8.0` に上げる
   - WEBRTC_BUILD_VERSION を `m130.6723.2.0` に上げる
     - libwebrtc のモジュール分割に追従するため rtc::CreateRandomString のヘッダを追加
+    - Sora CPP SDK の absl::optional を std::optional に変更した仕様に追従する
+    - Sora CPP SDK の absl::nullopt を std::nullopt に変更した仕様に追従する
   - CMAKE_VERSION を `3.30.5` に上げる
   - BOOST_VERSION を `1.86.0` に上げる
   - OPENH264_VERSION を `v2.5.0` に上げる

--- a/src/dynamic_h264_decoder.cpp
+++ b/src/dynamic_h264_decoder.cpp
@@ -89,7 +89,7 @@ int32_t DynamicH264Decoder::Decode(const EncodedImage& input_image,
   }
 
   h264_bitstream_parser_.ParseBitstream(input_image);
-  absl::optional<int> qp = h264_bitstream_parser_.GetLastSliceQp();
+  std::optional<int> qp = h264_bitstream_parser_.GetLastSliceQp();
 
   std::array<std::uint8_t*, 3> yuv;
   SBufferInfo info = {};
@@ -127,7 +127,7 @@ int32_t DynamicH264Decoder::Decode(const EncodedImage& input_image,
     video_frame.set_color_space(*input_image.ColorSpace());
   }
 
-  callback_->Decoded(video_frame, absl::nullopt, qp);
+  callback_->Decoded(video_frame, std::nullopt, qp);
 
   return WEBRTC_VIDEO_CODEC_OK;
 }

--- a/src/dynamic_h264_encoder.cpp
+++ b/src/dynamic_h264_encoder.cpp
@@ -62,7 +62,7 @@ enum DynamicH264EncoderEvent {
   kH264EncoderEventMax = 16,
 };
 
-int NumberOfThreads(absl::optional<int> encoder_thread_limit,
+int NumberOfThreads(std::optional<int> encoder_thread_limit,
                     int width,
                     int height,
                     int number_of_cores) {
@@ -106,7 +106,7 @@ VideoFrameType ConvertToVideoFrameType(EVideoFrameType type) {
   return VideoFrameType::kEmptyFrame;
 }
 
-absl::optional<ScalabilityMode> ScalabilityModeFromTemporalLayers(
+std::optional<ScalabilityMode> ScalabilityModeFromTemporalLayers(
     int num_temporal_layers) {
   switch (num_temporal_layers) {
     case 0:
@@ -120,7 +120,7 @@ absl::optional<ScalabilityMode> ScalabilityModeFromTemporalLayers(
     default:
       RTC_DCHECK_NOTREACHED();
   }
-  return absl::nullopt;
+  return std::nullopt;
 }
 
 }  // namespace

--- a/src/dynamic_h264_encoder.h
+++ b/src/dynamic_h264_encoder.h
@@ -114,7 +114,7 @@ class DynamicH264Encoder : public VideoEncoder {
   std::vector<LayerConfig> configurations_;
   std::vector<EncodedImage> encoded_images_;
   std::vector<std::unique_ptr<ScalableVideoController>> svc_controllers_;
-  absl::InlinedVector<absl::optional<ScalabilityMode>, kMaxSimulcastStreams>
+  absl::InlinedVector<std::optional<ScalabilityMode>, kMaxSimulcastStreams>
       scalability_modes_;
 
   const Environment env_;
@@ -122,7 +122,7 @@ class DynamicH264Encoder : public VideoEncoder {
   H264PacketizationMode packetization_mode_;
   size_t max_payload_size_;
   int32_t number_of_cores_;
-  absl::optional<int> encoder_thread_limit_;
+  std::optional<int> encoder_thread_limit_;
   EncodedImageCallback* encoded_image_callback_;
 
   bool has_reported_init_;

--- a/src/sora_audio_sink.cpp
+++ b/src/sora_audio_sink.cpp
@@ -53,7 +53,7 @@ void SoraAudioSinkImpl::OnData(
     int sample_rate,
     size_t number_of_channels,
     size_t number_of_frames,
-    absl::optional<int64_t> absolute_capture_timestamp_ms) {
+    std::optional<int64_t> absolute_capture_timestamp_ms) {
   if (absolute_capture_timestamp_ms) {
     audio_frame_->set_absolute_capture_timestamp_ms(
         *absolute_capture_timestamp_ms);

--- a/src/sora_audio_sink.h
+++ b/src/sora_audio_sink.h
@@ -50,7 +50,7 @@ class SoraAudioSinkImpl : public webrtc::AudioTrackSinkInterface,
               int sample_rate,
               size_t number_of_channels,
               size_t number_of_frames,
-              absl::optional<int64_t> absolute_capture_timestamp_ms) override;
+              std::optional<int64_t> absolute_capture_timestamp_ms) override;
 
   /**
    * 実装上の留意点：コールバックと Read 関数の共存はパフォーマンスや使い方の面で難しいことが判明したので、

--- a/src/sora_audio_source.cpp
+++ b/src/sora_audio_source.cpp
@@ -17,7 +17,7 @@ SoraAudioSourceInterface::~SoraAudioSourceInterface() {
 
 void SoraAudioSourceInterface::OnData(const int16_t* data,
                                       size_t samples_per_channel,
-                                      absl::optional<int64_t> timestamp) {
+                                      std::optional<int64_t> timestamp) {
   size_t size = samples_per_channel * channels_;
   if (buffer_used_ > 0) {
     // 先に 10 ms に満たず残したデータを新たなデータと繋げて 10 ms を超える場合は送る
@@ -116,7 +116,7 @@ void SoraAudioSourceInterface::RemoveSink(
 }
 
 void SoraAudioSourceInterface::Add10MsData(const int16_t* data,
-                                           absl::optional<int64_t> timestamp) {
+                                           std::optional<int64_t> timestamp) {
   if (timestamp) {
     last_timestamp_ = *timestamp;
   }
@@ -146,7 +146,7 @@ void SoraAudioSource::OnData(const int16_t* data,
 }
 
 void SoraAudioSource::OnData(const int16_t* data, size_t samples_per_channel) {
-  source_->OnData(data, samples_per_channel, absl::nullopt);
+  source_->OnData(data, samples_per_channel, std::nullopt);
 }
 
 void SoraAudioSource::OnData(
@@ -166,5 +166,5 @@ void SoraAudioSource::OnData(
   if (!track_) {
     return;
   }
-  source_->OnData(ndarray.data(), ndarray.shape(0), absl::nullopt);
+  source_->OnData(ndarray.data(), ndarray.shape(0), std::nullopt);
 }

--- a/src/sora_audio_source.h
+++ b/src/sora_audio_source.h
@@ -32,7 +32,7 @@ class SoraAudioSourceInterface
 
   void OnData(const int16_t* data,
               size_t samples_per_channel,
-              absl::optional<int64_t> timestamp);
+              std::optional<int64_t> timestamp);
 
   // MediaSourceInterface implementation.
   webrtc::MediaSourceInterface::SourceState state() const override;
@@ -46,7 +46,7 @@ class SoraAudioSourceInterface
   void RemoveSink(webrtc::AudioTrackSinkInterface* sink) override;
 
  private:
-  void Add10MsData(const int16_t* data, absl::optional<int64_t> timestamp);
+  void Add10MsData(const int16_t* data, std::optional<int64_t> timestamp);
 
   std::list<AudioObserver*> audio_observers_;
   webrtc::Mutex sink_lock_;

--- a/src/sora_audio_stream_sink.cpp
+++ b/src/sora_audio_stream_sink.cpp
@@ -179,7 +179,7 @@ void SoraAudioStreamSinkImpl::OnData(
     int sample_rate,
     size_t number_of_channels,
     size_t number_of_frames,
-    absl::optional<int64_t> absolute_capture_timestamp_ms) {
+    std::optional<int64_t> absolute_capture_timestamp_ms) {
   auto tuned_frame = std::make_unique<webrtc::AudioFrame>();
   tuned_frame->UpdateFrame(
       0, static_cast<const int16_t*>(audio_data), number_of_frames, sample_rate,

--- a/src/sora_audio_stream_sink.h
+++ b/src/sora_audio_stream_sink.h
@@ -180,7 +180,7 @@ class SoraAudioStreamSinkImpl : public webrtc::AudioTrackSinkInterface,
               int sample_rate,
               size_t number_of_channels,
               size_t number_of_frames,
-              absl::optional<int64_t> absolute_capture_timestamp_ms) override;
+              std::optional<int64_t> absolute_capture_timestamp_ms) override;
   /**
    * 音声データが来るたびに呼び出されるコールバック変数です。
    * 


### PR DESCRIPTION
This pull request primarily focuses on updating the codebase to replace `absl::optional` and `absl::nullopt` with `std::optional` and `std::nullopt` respectively. These changes span across multiple files and functions to ensure consistency and compatibility with the updated Sora C++ SDK.

Key changes include:

### SDK and Dependency Updates:
* Updated Sora C++ SDK to version `2024.8.0`, which includes changes from `absl::optional` to `std::optional` and from `absl::nullopt` to `std::nullopt`.

### Decoder Changes:
* Replaced `absl::optional<int>` with `std::optional<int>` in `DynamicH264Decoder::Decode`.
* Updated the call to `callback_->Decoded` to use `std::nullopt` instead of `absl::nullopt`.

### Encoder Changes:
* Changed `NumberOfThreads` function to use `std::optional<int>` instead of `absl::optional<int>`.
* Updated `ScalabilityModeFromTemporalLayers` to return `std::optional<ScalabilityMode>` and use `std::nullopt`. [[1]](diffhunk://#diff-2e0493445e171a998127f0191437948aac7557e6d47cd62062d9010dbe5e0098L109-R109) [[2]](diffhunk://#diff-2e0493445e171a998127f0191437948aac7557e6d47cd62062d9010dbe5e0098L123-R123)
* Modified `DynamicH264Encoder` class to use `std::optional` for `scalability_modes_` and `encoder_thread_limit_` members.

### Audio Handling Changes:
* Updated `SoraAudioSinkImpl::OnData` and `SoraAudioSourceInterface::OnData` to use `std::optional<int64_t>` instead of `absl::optional<int64_t>`. [[1]](diffhunk://#diff-49bfe0a75e9af7f5922b260b469949727ffd57f5f034e46ec57b293dde1249b7L56-R56) [[2]](diffhunk://#diff-e5ea8af063ef15147d50b2c8c8310c0b198a7138ee366c99f77c54a3146184c6L20-R20)
* Changed `SoraAudioSourceInterface::Add10MsData` and `SoraAudioSource::OnData` to use `std::optional<int64_t>` and `std::nullopt`. [[1]](diffhunk://#diff-e5ea8af063ef15147d50b2c8c8310c0b198a7138ee366c99f77c54a3146184c6L119-R119) [[2]](diffhunk://#diff-e5ea8af063ef15147d50b2c8c8310c0b198a7138ee366c99f77c54a3146184c6L149-R149) [[3]](diffhunk://#diff-e5ea8af063ef15147d50b2c8c8310c0b198a7138ee366c99f77c54a3146184c6L169-R169)
* Modified `SoraAudioStreamSinkImpl::OnData` to use `std::optional<int64_t>` instead of `absl::optional<int64_t>`.

These updates ensure that the codebase is aligned with the latest standards and improves overall maintainability and compatibility.