### PR TITLE
transport-wide-cc-extensions-01 の出力に合わせてテストを変更する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -99,6 +99,14 @@
   - @voluntas
 - [ADD] examples に E2E テストを追加する
   - @voluntas
+- [FIX] トランスポートワイド輻輳制御を有効時の出力に合わせてサイマルキャストの E2E テストを変更する
+  - Sora のトランスポートワイド輻輳制御を有効にしたことで、サイマルキャストの WebRTC Stats の outbound-rtp -> encoderImplementation の出力内容が変わったため、テストの期待結果を修正する
+  - Sora のトランスポートワイド輻輳制御は有効であることを前提とした修正
+  - サイマルキャストの encoderImplementation の結果を以下の通り
+    - "SimulcastEncoderAdapter (libaom, libaom, libaom)" -> "SimulcastEncoderAdapter (libaom)"
+    - "SimulcastEncoderAdapter (libvpx, libvpx, libvpx)" -> "SimulcastEncoderAdapter (libvpx)"
+    - "SimulcastEncoderAdapter (OpenH264, OpenH264, OpenH264)" -> "SimulcastEncoderAdapter (OpenH264)"
+    - "SimulcastEncoderAdapter (VideoToolbox, VideoToolbox, VideoToolbox)" -> "SimulcastEncoderAdapter (VideoToolbox)"
 
 ## 2024.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -99,14 +99,13 @@
   - @voluntas
 - [ADD] examples に E2E テストを追加する
   - @voluntas
-- [FIX] トランスポートワイド輻輳制御を有効時の出力に合わせてサイマルキャストの E2E テストを変更する
-  - Sora のトランスポートワイド輻輳制御を有効にしたことで、サイマルキャストの WebRTC Stats の outbound-rtp -> encoderImplementation の出力内容が変わったため、テストの期待結果を修正する
-  - Sora のトランスポートワイド輻輳制御は有効であることを前提とした修正
+- [FIX] サイマルキャストの E2E テストについて encoderImplementation の値チェック内容を緩和する
+  - サイマルキャストの encoderImplementation のチェックを文字列一致としていたが、帯域推定機能を有効にした後、値が安定しなくなったためチェック内容を緩和した
   - サイマルキャストの encoderImplementation の結果を以下の通り
-    - "SimulcastEncoderAdapter (libaom, libaom, libaom)" -> "SimulcastEncoderAdapter (libaom)"
-    - "SimulcastEncoderAdapter (libvpx, libvpx, libvpx)" -> "SimulcastEncoderAdapter (libvpx)"
-    - "SimulcastEncoderAdapter (OpenH264, OpenH264, OpenH264)" -> "SimulcastEncoderAdapter (OpenH264)"
-    - "SimulcastEncoderAdapter (VideoToolbox, VideoToolbox, VideoToolbox)" -> "SimulcastEncoderAdapter (VideoToolbox)"
+    - "SimulcastEncoderAdapter (libaom, libaom, libaom)" -> "libaom" を含む
+    - "SimulcastEncoderAdapter (libvpx, libvpx, libvpx)" -> "libvpx" を含む
+    - "SimulcastEncoderAdapter (OpenH264, OpenH264, OpenH264)" -> "OpenH264" を含む
+    - "SimulcastEncoderAdapter (VideoToolbox, VideoToolbox, VideoToolbox)" -> "VideoToolbox" を含む
 
 ## 2024.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,11 +101,11 @@
   - @voluntas
 - [FIX] サイマルキャストの E2E テストについて encoderImplementation の値チェック内容を緩和する
   - サイマルキャストの encoderImplementation のチェックを文字列一致としていたが、帯域推定機能を有効にした後、値が安定しなくなったためチェック内容を緩和した
-  - サイマルキャストの encoderImplementation の結果を以下の通り
-    - "SimulcastEncoderAdapter (libaom, libaom, libaom)" -> "libaom" を含む
-    - "SimulcastEncoderAdapter (libvpx, libvpx, libvpx)" -> "libvpx" を含む
-    - "SimulcastEncoderAdapter (OpenH264, OpenH264, OpenH264)" -> "OpenH264" を含む
-    - "SimulcastEncoderAdapter (VideoToolbox, VideoToolbox, VideoToolbox)" -> "VideoToolbox" を含む
+  - サイマルキャストの encoderImplementation の結果を以下の通り修正
+    - "SimulcastEncoderAdapter (libaom, libaom, libaom)" -> "SimulcastEncoderAdapter" と "libaom" を含む
+    - "SimulcastEncoderAdapter (libvpx, libvpx, libvpx)" -> "SimulcastEncoderAdapter" と "libvpx" を含む
+    - "SimulcastEncoderAdapter (OpenH264, OpenH264, OpenH264)" -> "SimulcastEncoderAdapter" と "OpenH264" を含む
+    - "SimulcastEncoderAdapter (VideoToolbox, VideoToolbox, VideoToolbox)" -> "SimulcastEncoderAdapter" と "VideoToolbox" を含む
 
 ## 2024.3.0
 

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -62,8 +62,8 @@ def test_macos_video_hwa_sendonly(setup, video_codec_type):
 @pytest.mark.parametrize(
     ("video_codec_type", "expected_implementation"),
     [
-        ("H264", "SimulcastEncoderAdapter (VideoToolbox, VideoToolbox, VideoToolbox)"),
-        ("H265", "SimulcastEncoderAdapter (VideoToolbox, VideoToolbox, VideoToolbox)"),
+        ("H264", "SimulcastEncoderAdapter (VideoToolbox)"),
+        ("H265", "SimulcastEncoderAdapter (VideoToolbox)"),
     ],
 )
 def test_macos_simulcast(setup, video_codec_type, expected_implementation):

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -115,6 +115,7 @@ def test_macos_simulcast(setup, video_codec_type, expected_implementation):
 
     for i, rtp_stat in enumerate(sorted_stats):
         assert rtp_stat["rid"] == f"r{i}"
+        assert "SimulcastEncoderAdapter" in rtp_stat["encoderImplementation"]
         assert expected_implementation in rtp_stat["encoderImplementation"]
         assert rtp_stat["bytesSent"] > 0
         assert rtp_stat["packetsSent"] > 0

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -62,8 +62,8 @@ def test_macos_video_hwa_sendonly(setup, video_codec_type):
 @pytest.mark.parametrize(
     ("video_codec_type", "expected_implementation"),
     [
-        ("H264", "SimulcastEncoderAdapter (VideoToolbox)"),
-        ("H265", "SimulcastEncoderAdapter (VideoToolbox)"),
+        ("H264", "SimulcastEncoderAdapter (VideoToolbox, VideoToolbox)"),
+        ("H265", "SimulcastEncoderAdapter (VideoToolbox, VideoToolbox)"),
     ],
 )
 def test_macos_simulcast(setup, video_codec_type, expected_implementation):

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -62,8 +62,8 @@ def test_macos_video_hwa_sendonly(setup, video_codec_type):
 @pytest.mark.parametrize(
     ("video_codec_type", "expected_implementation"),
     [
-        ("H264", "SimulcastEncoderAdapter (VideoToolbox, VideoToolbox)"),
-        ("H265", "SimulcastEncoderAdapter (VideoToolbox, VideoToolbox)"),
+        ("H264", "VideoToolbox"),
+        ("H265", "VideoToolbox"),
     ],
 )
 def test_macos_simulcast(setup, video_codec_type, expected_implementation):
@@ -89,7 +89,7 @@ def test_macos_simulcast(setup, video_codec_type, expected_implementation):
     )
     sendonly.connect(fake_video=True)
 
-    time.sleep(5)
+    time.sleep(10)
 
     sendonly_stats = sendonly.get_stats()
 
@@ -115,7 +115,7 @@ def test_macos_simulcast(setup, video_codec_type, expected_implementation):
 
     for i, rtp_stat in enumerate(sorted_stats):
         assert rtp_stat["rid"] == f"r{i}"
-        assert rtp_stat["encoderImplementation"] == expected_implementation
+        assert expected_implementation in rtp_stat["encoderImplementation"]
         assert rtp_stat["bytesSent"] > 0
         assert rtp_stat["packetsSent"] > 0
 

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -89,7 +89,7 @@ def test_macos_simulcast(setup, video_codec_type, expected_implementation):
     )
     sendonly.connect(fake_video=True)
 
-    time.sleep(10)
+    time.sleep(5)
 
     sendonly_stats = sendonly.get_stats()
 

--- a/tests/test_openh264.py
+++ b/tests/test_openh264.py
@@ -122,6 +122,7 @@ def test_openh264_simulcast(setup, video_codec_type, expected_implementation):
 
     for i, rtp_stat in enumerate(sorted_stats):
         assert rtp_stat["rid"] == f"r{i}"
+        assert "SimulcastEncoderAdapter" in rtp_stat["encoderImplementation"]
         assert expected_implementation in rtp_stat["encoderImplementation"]
         assert rtp_stat["bytesSent"] > 0
         assert rtp_stat["packetsSent"] > 0

--- a/tests/test_openh264.py
+++ b/tests/test_openh264.py
@@ -72,7 +72,7 @@ def test_openh264_sendonly_recvonly(setup):
 @pytest.mark.parametrize(
     "video_codec_type,expected_implementation",
     [
-        ("H264", "SimulcastEncoderAdapter (OpenH264)"),
+        ("H264", "SimulcastEncoderAdapter (OpenH264, OpenH264)"),
     ],
 )
 def test_openh264_simulcast(setup, video_codec_type, expected_implementation):

--- a/tests/test_openh264.py
+++ b/tests/test_openh264.py
@@ -72,7 +72,7 @@ def test_openh264_sendonly_recvonly(setup):
 @pytest.mark.parametrize(
     "video_codec_type,expected_implementation",
     [
-        ("H264", "SimulcastEncoderAdapter (OpenH264, OpenH264, OpenH264)"),
+        ("H264", "SimulcastEncoderAdapter (OpenH264)"),
     ],
 )
 def test_openh264_simulcast(setup, video_codec_type, expected_implementation):

--- a/tests/test_openh264.py
+++ b/tests/test_openh264.py
@@ -101,7 +101,7 @@ def test_openh264_simulcast(setup, video_codec_type, expected_implementation):
     )
     sendonly.connect(fake_video=True)
 
-    time.sleep(10)
+    time.sleep(5)
 
     sendonly_stats = sendonly.get_stats()
 

--- a/tests/test_openh264.py
+++ b/tests/test_openh264.py
@@ -72,7 +72,7 @@ def test_openh264_sendonly_recvonly(setup):
 @pytest.mark.parametrize(
     "video_codec_type,expected_implementation",
     [
-        ("H264", "SimulcastEncoderAdapter (OpenH264, OpenH264)"),
+        ("H264", "OpenH264"),
     ],
 )
 def test_openh264_simulcast(setup, video_codec_type, expected_implementation):
@@ -101,7 +101,7 @@ def test_openh264_simulcast(setup, video_codec_type, expected_implementation):
     )
     sendonly.connect(fake_video=True)
 
-    time.sleep(5)
+    time.sleep(10)
 
     sendonly_stats = sendonly.get_stats()
 
@@ -122,6 +122,6 @@ def test_openh264_simulcast(setup, video_codec_type, expected_implementation):
 
     for i, rtp_stat in enumerate(sorted_stats):
         assert rtp_stat["rid"] == f"r{i}"
-        assert rtp_stat["encoderImplementation"] == expected_implementation
+        assert expected_implementation in rtp_stat["encoderImplementation"]
         assert rtp_stat["bytesSent"] > 0
         assert rtp_stat["packetsSent"] > 0

--- a/tests/test_simulcast.py
+++ b/tests/test_simulcast.py
@@ -10,7 +10,7 @@ from client import SoraClient, SoraRole
     ("video_codec_type", "expected_implementation"),
     [
         ("VP8", "SimulcastEncoderAdapter (libvpx)"),
-        ("VP9", "SimulcastEncoderAdapter (libvpx)"),
+        ("VP9", "SimulcastEncoderAdapter (libvpx, libvpx, libvpx)"),
         ("AV1", "SimulcastEncoderAdapter (libaom)"),
     ],
 )
@@ -65,4 +65,3 @@ def test_simulcast(setup, video_codec_type, expected_implementation):
         assert rtp_stat["encoderImplementation"] == expected_implementation
         assert rtp_stat["bytesSent"] > 0
         assert rtp_stat["packetsSent"] > 0
-

--- a/tests/test_simulcast.py
+++ b/tests/test_simulcast.py
@@ -62,6 +62,7 @@ def test_simulcast(setup, video_codec_type, expected_implementation):
 
     for i, rtp_stat in enumerate(sorted_stats):
         assert rtp_stat["rid"] == f"r{i}"
+        assert "SimulcastEncoderAdapter" in rtp_stat["encoderImplementation"]
         assert expected_implementation in rtp_stat["encoderImplementation"]
         assert rtp_stat["bytesSent"] > 0
         assert rtp_stat["packetsSent"] > 0

--- a/tests/test_simulcast.py
+++ b/tests/test_simulcast.py
@@ -9,9 +9,9 @@ from client import SoraClient, SoraRole
 @pytest.mark.parametrize(
     ("video_codec_type", "expected_implementation"),
     [
-        ("VP8", "SimulcastEncoderAdapter (libvpx, libvpx, libvpx)"),
-        ("VP9", "SimulcastEncoderAdapter (libvpx, libvpx, libvpx)"),
-        ("AV1", "SimulcastEncoderAdapter (libaom, libaom, libaom)"),
+        ("VP8", "SimulcastEncoderAdapter (libvpx)"),
+        ("VP9", "SimulcastEncoderAdapter (libvpx)"),
+        ("AV1", "SimulcastEncoderAdapter (libaom)"),
     ],
 )
 def test_simulcast(setup, video_codec_type, expected_implementation):

--- a/tests/test_simulcast.py
+++ b/tests/test_simulcast.py
@@ -9,9 +9,9 @@ from client import SoraClient, SoraRole
 @pytest.mark.parametrize(
     ("video_codec_type", "expected_implementation"),
     [
-        ("VP8", "SimulcastEncoderAdapter (libvpx)"),
-        ("VP9", "SimulcastEncoderAdapter (libvpx, libvpx, libvpx)"),
-        ("AV1", "SimulcastEncoderAdapter (libaom)"),
+        ("VP8", "libvpx"),
+        ("VP9", "libvpx"),
+        ("AV1", "libaom"),
     ],
 )
 def test_simulcast(setup, video_codec_type, expected_implementation):
@@ -62,6 +62,6 @@ def test_simulcast(setup, video_codec_type, expected_implementation):
 
     for i, rtp_stat in enumerate(sorted_stats):
         assert rtp_stat["rid"] == f"r{i}"
-        assert rtp_stat["encoderImplementation"] == expected_implementation
+        assert expected_implementation in rtp_stat["encoderImplementation"]
         assert rtp_stat["bytesSent"] > 0
         assert rtp_stat["packetsSent"] > 0


### PR DESCRIPTION
Sora 側の設定でトランスポートワイド輻輳制御を有効にしたところ、Stats の outbound-rtp の encoderImplementation が変わったため、テストが失敗しました。

Sora 側の設定は今後もトランスポートワイド輻輳制御を有効にするので設定に合わせてテスト結果の判定を修正します。

---
This pull request includes changes to the `tests/test_openh264.py` and `tests/test_simulcast.py` files to update the expected implementation strings for various video codecs.

Updates to expected implementation strings:

* [`tests/test_openh264.py`](diffhunk://#diff-ad1cdfef9d73d08f72ddc3980149071b3a7e305d31b1bd3f5b4d5bc5291c4780L75-R75): Modified the expected implementation string for the "H264" codec in the `test_openh264_simulcast` test case to use a single instance of `OpenH264` instead of three.
* [`tests/test_simulcast.py`](diffhunk://#diff-12c32fa52aed65d3b377524826b0d0b39608eecdeed45c41fee705d957b750c3L12-R14): Updated the expected implementation strings for the "VP8", "VP9", and "AV1" codecs in the `test_simulcast` test case to use a single instance of the respective codec libraries instead of three.