### PR TITLE
nanobind が libstdc++ を使ってしまっていたのを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,8 @@
   - BOOST_VERSION を `1.87.0` に上げる
   - OPENH264_VERSION を `v2.5.0` に上げる
   - @torikizi @voluntas
+- [FIX] nanobind が libstdc++ を使ってしまっていたのを libc++ を使うように修正する
+  - @melpon
 
 ### misc
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,11 +105,23 @@ elseif(TARGET_OS STREQUAL "ubuntu")
       "$<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>"
       "$<$<COMPILE_LANGUAGE:CXX>:-isystem${LIBCXX_INCLUDE_DIR}>"
   )
+  target_compile_options(nanobind-static
+    PRIVATE
+      "$<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>"
+      "$<$<COMPILE_LANGUAGE:CXX>:-isystem${LIBCXX_INCLUDE_DIR}>"
+      "$<$<COMPILE_LANGUAGE:CXX>:-isystem${LIBCXXABI_INCLUDE_DIR}>"
+  )
 elseif(TARGET_OS STREQUAL "jetson")
   target_compile_options(sora_sdk_ext
     PRIVATE
       "$<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>"
       "$<$<COMPILE_LANGUAGE:CXX>:-isystem${LIBCXX_INCLUDE_DIR}>"
+  )
+  target_compile_options(nanobind-static
+    PRIVATE
+      "$<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>"
+      "$<$<COMPILE_LANGUAGE:CXX>:-isystem${LIBCXX_INCLUDE_DIR}>"
+      "$<$<COMPILE_LANGUAGE:CXX>:-isystem${LIBCXXABI_INCLUDE_DIR}>"
   )
   target_link_directories(sora_sdk_ext
     PRIVATE
@@ -143,6 +155,7 @@ if (NOT TARGET_OS STREQUAL "windows")
 endif()
 
 target_link_libraries(sora_sdk_ext PRIVATE Sora::sora)
+target_link_libraries(nanobind-static PRIVATE Sora::sora)
 
 install(TARGETS sora_sdk_ext LIBRARY DESTINATION .)
 if (SORA_GEN_PYI)

--- a/buildbase.py
+++ b/buildbase.py
@@ -520,6 +520,7 @@ class WebrtcInfo(NamedTuple):
     webrtc_library_dir: str
     clang_dir: str
     libcxx_dir: str
+    libcxxabi_dir: str
 
 
 def get_webrtc_info(
@@ -536,6 +537,9 @@ def get_webrtc_info(
             webrtc_library_dir=os.path.join(webrtc_install_dir, "lib"),
             clang_dir=os.path.join(install_dir, "llvm", "clang"),
             libcxx_dir=os.path.join(install_dir, "llvm", "libcxx"),
+            libcxxabi_dir=os.path.join(
+                webrtc_install_dir, "include", "third_party", "libc++abi", "src"
+            ),
         )
     else:
         webrtc_build_source_dir = os.path.join(
@@ -556,6 +560,9 @@ def get_webrtc_info(
                 webrtc_build_source_dir, "src", "third_party", "llvm-build", "Release+Asserts"
             ),
             libcxx_dir=os.path.join(webrtc_build_source_dir, "src", "third_party", "libc++", "src"),
+            libcxxabi_dir=os.path.join(
+                webrtc_build_source_dir, "src", "third_party", "libc++abi", "src"
+            ),
         )
 
 

--- a/run.py
+++ b/run.py
@@ -275,6 +275,7 @@ def main():
                 ]
             cmake_args += [
                 f"-DLIBCXX_INCLUDE_DIR={cmake_path(os.path.join(webrtc_info.libcxx_dir, 'include'))}",
+                f"-DLIBCXXABI_INCLUDE_DIR={cmake_path(os.path.join(webrtc_info.libcxxabi_dir, 'include'))}",
             ]
 
             if platform.build.arch != platform.target.arch:


### PR DESCRIPTION
nanobind が libc++ ではなく libstdc++ を使っていたので、libc++ を使うように修正しました。

sora_sdk_ext 自体は libc++ を利用していたため、ABI が混ざっておかしな動作になっていました。
具体的には、

```cpp
NB_MODULE(sora_sdk_ext, m) {
  m.def("f", []() { throw std::exception(); });
}
```
```python
from sora_sdk import f
f()
```

とした時に、通常は RuntimeError が出るはずですが、プログラムが SIGABRT で落ちていました。

ABI が混ざっている影響は他にもあるかもしれないので、安定動作に繋がるかもです。