### PR TITLE
[WIP] NVIDIA-Video-Codec-SDK の E2E テスト追加

### DIFF
--- a/.github/workflows/e2e-test-nvidia-video-codec-sdk.yml
+++ b/.github/workflows/e2e-test-nvidia-video-codec-sdk.yml
@@ -1,0 +1,81 @@
+name: e2e-test-nvidia-video-codec-sdk
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - ".github/workflows/e2e-test-nvidia-video-codec-sdk.yml"
+      - "tests/test_nvidia_video_codec_sdk.py"
+      # C++ SDK のアップデートしたときテストするため
+      - "VERSION"
+  schedule:
+    # UTC の 01:00 は JST だと 10:00 。
+    # 1-5 で 月曜日から金曜日
+    - cron: "0 1 * * 1-5"
+
+env:
+  TEST_SIGNALING_URLS: ${{ secrets.TEST_SIGNALING_URLS }}
+  TEST_CHANNEL_ID_PREFIX: ${{ secrets.TEST_CHANNEL_ID_PREFIX }}
+  TEST_SECRET_KEY: ${{ secrets.TEST_SECRET_KEY }}
+  TEST_API_URL: ${{ secrets.TEST_API_URL }}
+  NVIDIA_VIDEO_CODEC_SDK: true
+
+jobs:
+  e2e_test_nvidia_video_codec_sdk:
+    strategy:
+      fail-fast: true
+      matrix:
+        python_version:
+          # TODO: push 時には 3.13 でテストする、schedule 時には全部でテストする
+          # - "3.11"
+          # - "3.12"
+          - "3.13"
+    runs-on:
+      group: Self
+      labels: [self-hosted, linux, x64, NVIDIA-Video-Codec-SDK]
+    timeout-minutes: 15
+    if: >-
+      ${{
+        contains(github.event.head_commit.message, '[e2e]') ||
+        contains(github.ref, 'feature/e2e-test') ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'push' ||
+        github.event_name == 'schedule'
+      }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: false
+      - run: uv python pin ${{ matrix.python_version }}
+      - run: uv sync
+      - run: uv run python run.py ubuntu-24.04_x86_64
+      - run: uv run pytest tests/test_nvidia_video_codec_sdk.py -v
+
+  # slack_notify_succeeded:
+  #   needs: [e2e_test_intel_vpl]
+  #   runs-on: ubuntu-24.04
+  #   if: success()
+  #   steps:
+  #     - name: Slack Notification
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: sora-python-sdk
+  #         SLACK_COLOR: good
+  #         SLACK_TITLE: SUCCEEDED
+  #         SLACK_ICON_EMOJI: ":star-struck:"
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  slack_notify_failed:
+    needs: [e2e_test_nvidia_video_codec_sdk]
+    runs-on: ubuntu-24.04
+    if: failure()
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: sora-python-sdk
+          SLACK_COLOR: danger
+          SLACK_TITLE: "FAILED"
+          SLACK_ICON_EMOJI: ":japanese_ogre:"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}  


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to perform end-to-end tests for the NVIDIA Video Codec SDK. The workflow is triggered by various events and includes steps to set up the environment, run tests, and notify on failure.

Key changes include:

* **New Workflow Addition:**
  * Added a new workflow file `.github/workflows/e2e-test-nvidia-video-codec-sdk.yml` to perform end-to-end tests for the NVIDIA Video Codec SDK.

* **Environment Setup:**
  * Configured environment variables for testing, including `TEST_SIGNALING_URLS`, `TEST_CHANNEL_ID_PREFIX`, `TEST_SECRET_KEY`, `TEST_API_URL`, and `NVIDIA_VIDEO_CODEC_SDK`.

* **Job Configuration:**
  * Defined a job `e2e_test_nvidia_video_codec_sdk` with a matrix strategy to test different Python versions, initially set to test with Python 3.13.
  * Configured the job to run on self-hosted runners with specific labels, and set a timeout of 15 minutes.
  * Specified conditions for the job to run based on commit messages, branch names, and event types.

* **Testing Steps:**
  * Included steps to check out the repository, set up the environment, and