### PR TITLE
e2e test フルに回していく

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -26,54 +26,6 @@ env:
   OPENH264_VERSION: 2.6.0
 
 jobs:
-  # push 経由で実行される最小限の E2E テスト
-  e2e_test_minimal:
-    strategy:
-      fail-fast: false
-      matrix:
-        python_version: ["3.13"]
-        platform:
-          - target: "ubuntu-24.04_x86_64"
-            runs-on: "ubuntu-24.04"
-            arch: "x86_64"
-            openh264_arch: "linux64"
-    runs-on: ${{ matrix.platform.runs-on}}
-    timeout-minutes: 15
-    if: ${{ github.event_name == 'push' }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tailscale/github-action@v3
-        with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci
-      - run: |
-          sudo apt-get update
-          sudo apt-get -y install libva2 libdrm2 libx11-dev portaudio19-dev
-      - if: matrix.platform.arch == 'armv8'
-        run: |
-          sudo apt-get -y install multistrap binutils-aarch64-linux-gnu
-          # multistrap に insecure なリポジトリからの取得を許可する設定を入れる
-          sudo sed -e 's/Apt::Get::AllowUnauthenticated=true/Apt::Get::AllowUnauthenticated=true";\n$config_str .= " -o Acquire::AllowInsecureRepositories=true/' -i /usr/sbin/multistrap
-          # clang-18
-          wget https://apt.llvm.org/llvm.sh
-          chmod a+x llvm.sh
-          sudo ./llvm.sh 18
-      - name: Download openh264
-        run: |
-          curl -LO http://ciscobinary.openh264.org/libopenh264-${{ env.OPENH264_VERSION }}-${{ matrix.platform.openh264_arch }}.8.so.bz2
-          bzip2 -d libopenh264-${{ env.OPENH264_VERSION }}-${{ matrix.platform.openh264_arch }}.8.so.bz2
-          mv libopenh264-${{ env.OPENH264_VERSION }}-${{ matrix.platform.openh264_arch }}.8.so libopenh264.so
-          echo "OPENH264_PATH=$(pwd)/libopenh264.so" >> $GITHUB_ENV
-      - uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: false
-      - run: |
-          uv python pin ${{ matrix.python_version }}
-          uv sync
-          uv run python run.py ${{ matrix.platform.target }}
-          uv run pytest tests -v
-
   e2e_test_ubuntu:
     strategy:
       fail-fast: false
@@ -94,11 +46,6 @@ jobs:
             openh264_arch: "linux-arm64"
     runs-on: ${{ matrix.platform.runs-on}}
     timeout-minutes: 15
-    if: >-
-      ${{
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'schedule'
-      }}
     steps:
       - uses: actions/checkout@v4
       - uses: tailscale/github-action@v3
@@ -142,11 +89,6 @@ jobs:
         os: ["macos-14", "macos-15"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
-    if: >-
-      ${{
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'schedule'
-      }}
     steps:
       - uses: actions/checkout@v4
       - name: Download openh264
@@ -174,11 +116,6 @@ jobs:
     env:
       # Python を強制的に UTF-8 で利用するおまじない
       PYTHONUTF8: 1
-    if: >-
-      ${{
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'schedule'
-      }}
     steps:
       - uses: actions/checkout@v4
       - name: Download openh264
@@ -213,7 +150,7 @@ jobs:
   #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   slack_notify_failed:
-    needs: [e2e_test_minimal,e2e_test_ubuntu, e2e_test_macos, e2e_test_windows]
+    needs: [e2e_test_ubuntu, e2e_test_macos, e2e_test_windows]
     runs-on: ubuntu-24.04
     if: failure()
     steps:


### PR DESCRIPTION
This pull request includes significant changes to the `.github/workflows/e2e-test.yml` file, primarily focusing on the removal of the minimal E2E test job and the conditions for running certain jobs. The most important changes include the deletion of the `e2e_test_minimal` job and the removal of conditional checks for specific events.

Changes to E2E test jobs:

* Removed the `e2e_test_minimal` job, which included various steps like checking out code, installing dependencies, and running tests. This job was executed via push events.

* Deleted the conditional checks for running the `e2e_test_ubuntu`, `e2e_test_macos`, and `e2e_test_windows` jobs based on specific GitHub events (`workflow_dispatch` or `schedule`). [[1]](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2L97-L101) [[2]](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2L145-L149) [[3]](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2L177-L181)

Other changes:

* Updated the `slack_notify_failed` job to remove its dependency on the now-deleted `e2e_test_minimal` job.