### PR TITLE
user_agent 引数を追加

### DIFF
--- a/src/sora.cpp
+++ b/src/sora.cpp
@@ -72,7 +72,8 @@ nb::ref<SoraConnection> Sora::CreateConnection(
     std::optional<std::string> proxy_username,
     std::optional<std::string> proxy_password,
     std::optional<std::string> proxy_agent,
-    std::optional<webrtc::DegradationPreference> degradation_preference) {
+    std::optional<webrtc::DegradationPreference> degradation_preference,
+    std::optional<std::string> user_agent) {
   std::shared_ptr<SoraSignalingObserver> observer(new SoraSignalingObserver());
   nb::ref<SoraConnection> conn = new SoraConnection(this, ioc_.get(), observer);
   observer->SetSoraConnection(conn);
@@ -195,6 +196,9 @@ nb::ref<SoraConnection> Sora::CreateConnection(
   }
   if (degradation_preference) {
     config.degradation_preference = *degradation_preference;
+  }
+  if (user_agent) {
+    config.user_agent = *user_agent;
   }
   config.network_manager = factory_->default_network_manager();
   config.socket_factory = factory_->default_socket_factory();

--- a/src/sora.h
+++ b/src/sora.h
@@ -90,6 +90,7 @@ class Sora : public CountedPublisher {
    * @param proxy_password (オプション) Proxy パスワード
    * @param proxy_agent (オプション) Proxy エージェント
    * @param degradation_preference (オプション) デグレード設定
+   * @param user_agent (オプション) User-Agent
    * @return SoraConnection インスタンス
    */
   nb::ref<SoraConnection> CreateConnection(
@@ -142,7 +143,8 @@ class Sora : public CountedPublisher {
       std::optional<std::string> proxy_username,
       std::optional<std::string> proxy_password,
       std::optional<std::string> proxy_agent,
-      std::optional<webrtc::DegradationPreference> degradation_preference);
+      std::optional<webrtc::DegradationPreference> degradation_preference,
+      std::optional<std::string> user_agent);
 
   /**
    * Sora に音声データを送る受け口である SoraAudioSource を生成します。

--- a/src/sora_sdk_ext.cpp
+++ b/src/sora_sdk_ext.cpp
@@ -747,7 +747,7 @@ NB_MODULE(sora_sdk_ext, m) {
            "client_key"_a = nb::none(), "ca_cert"_a = nb::none(),
            "proxy_url"_a = nb::none(), "proxy_username"_a = nb::none(),
            "proxy_password"_a = nb::none(), "proxy_agent"_a = nb::none(),
-           "degradation_preference"_a = nb::none(),
+           "degradation_preference"_a = nb::none(), "user_agent"_a = nb::none(),
            nb::sig("def create_connection("
                    "self, "
                    "signaling_urls: list[str], "
@@ -798,7 +798,8 @@ NB_MODULE(sora_sdk_ext, m) {
                    "proxy_password: Optional[str] = None, "
                    "proxy_agent: Optional[str] = None, "
                    "degradation_preference: "
-                   "Optional[SoraDegradationPreference] = None"
+                   "Optional[SoraDegradationPreference] = None, "
+                   "user_agent: Optional[str] = None"
                    ") -> SoraConnection"))
       .def("create_audio_source", &Sora::CreateAudioSource, "channels"_a,
            "sample_rate"_a)

--- a/tests/client.py
+++ b/tests/client.py
@@ -62,6 +62,7 @@ class SoraClient:
         client_cert: Optional[bytes] = None,
         ca_cert: Optional[bytes] = None,
         degradation_preference: Optional[SoraDegradationPreference] = None,
+        user_agent: Optional[str] = None,
         video_codec_preference: Optional[SoraVideoCodecPreference] = None,
         audio_channels: int = 1,
         audio_sample_rate: int = 16000,
@@ -153,6 +154,7 @@ class SoraClient:
             video_source=self._video_source,
             ca_cert=ca_cert,
             degradation_preference=self._degradation_preference,
+            user_agent=user_agent,
         )
 
         # "type": "offer" のパラメータ

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "sora-sdk"
-version = "2025.2.1"
+version = "2025.2.2"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Sora C++ SDK には User Agent を指定する設定が[既にある](https://github.com/shiguredo/sora-cpp-sdk/blob/64dc75a43341e467728fe4a1268958f9dc45eef7/include/sora/sora_signaling.h#L160) けど Python SDK 側に追加されてなかった。