### PR TITLE
Slack 通知を shiguredo/github-actions/slack-notify に切り替える

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,6 @@ updates:
       - dependency-name: "actions/upload-artifact"
       - dependency-name: "actions/download-artifact"
       - dependency-name: "actions/cache"
-      - dependency-name: "rtCamp/action-slack-notify"
       - dependency-name: "pypa/gh-action-pypi-publish"
       - dependency-name: "anthropics/claude-code-action"
       - dependency-name: "shiguredo/github-actions"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,10 +331,14 @@ jobs:
     runs-on: ubuntu-slim
     if: ${{ !cancelled() }}
     steps:
+      - name: Check build results
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
       - name: Slack Notification
+        if: ${{ !cancelled() }}
         uses: shiguredo/github-actions/.github/actions/slack-notify@main
         with:
-          status: ${{ (contains(needs.*.result, 'failure')) && 'failure' || 'success' }}
+          status: ${{ job.status }}
           slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
           slack_channel: sora-python-sdk
           notify_mode: failure_and_fixed
@@ -396,7 +400,7 @@ jobs:
         if: failure()
         uses: shiguredo/github-actions/.github/actions/slack-notify@main
         with:
-          status: failure
+          status: ${{ job.status }}
           slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
           slack_channel: sora-python-sdk
           notify_mode: all
@@ -496,7 +500,7 @@ jobs:
         if: failure()
         uses: shiguredo/github-actions/.github/actions/slack-notify@main
         with:
-          status: failure
+          status: ${{ job.status }}
           slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
           slack_channel: sora-python-sdk
           notify_mode: all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,11 +331,7 @@ jobs:
     runs-on: ubuntu-slim
     if: ${{ !cancelled() }}
     steps:
-      - name: Check build results
-        if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
       - name: Slack Notification
-        if: ${{ !cancelled() }}
         uses: shiguredo/github-actions/.github/actions/slack-notify@main
         with:
           status: ${{ job.status }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,20 +318,6 @@ jobs:
           name: ${{ matrix.platform.name }}_python-${{ matrix.python_version }}
           path: dist/
 
-  # slack_notify_succeeded:
-  #   needs: [build_ubuntu, build_ubuntu_arm, build_macos, build_windows]
-  #   runs-on: ubuntu-24.04
-  #   if: success()
-  #   steps:
-  #    - name: Slack Notification
-  #      uses: rtCamp/action-slack-notify@v2
-  #      env:
-  #        SLACK_CHANNEL: sora-python-sdk
-  #        SLACK_COLOR: good
-  #        SLACK_TITLE: SUCCEEDED
-  #        SLACK_ICON_EMOJI: ":star-struck:"
-  #        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
   # E2E テストの実行
   e2e_test:
     needs: [build_ubuntu, build_macos, build_windows]
@@ -340,19 +326,20 @@ jobs:
       from_build: true
     secrets: inherit
 
-  slack_notify_failed:
+  slack_notify:
     needs: [build_ubuntu, build_ubuntu_arm, build_macos, build_windows]
-    runs-on: ubuntu-24.04
-    if: failure()
+    runs-on: ubuntu-slim
+    if: ${{ !cancelled() }}
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: shiguredo/github-actions/.github/actions/slack-notify@main
+        with:
+          status: ${{ (contains(needs.*.result, 'failure')) && 'failure' || 'success' }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: sora-python-sdk
+          notify_mode: failure_and_fixed
         env:
-          SLACK_CHANNEL: sora-python-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: "FAILED"
-          SLACK_ICON_EMOJI: ":japanese_ogre:"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          GH_TOKEN: ${{ github.token }}
 
   publish_wheel:
     if: contains(github.ref, 'tags/202')
@@ -407,12 +394,14 @@ jobs:
 
       - name: Slack Notification
         if: failure()
-        uses: rtCamp/action-slack-notify@v2
+        uses: shiguredo/github-actions/.github/actions/slack-notify@main
+        with:
+          status: failure
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: sora-python-sdk
+          notify_mode: all
         env:
-          SLACK_CHANNEL: sora-python-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: Build failed
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          GH_TOKEN: ${{ github.token }}
 
   create-release:
     if: contains(github.ref, 'tags/202')
@@ -505,10 +494,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Slack Notification
         if: failure()
-        uses: rtCamp/action-slack-notify@v2
+        uses: shiguredo/github-actions/.github/actions/slack-notify@main
+        with:
+          status: failure
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: sora-python-sdk
+          notify_mode: all
         env:
-          SLACK_CHANNEL: sora-python-sdk
-          SLACK_COLOR: danger
-          SLACK_ICON_EMOJI: ":japanese_ogre:"
-          SLACK_TITLE: Release failed
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -249,10 +249,14 @@ jobs:
     runs-on: ubuntu-slim
     if: ${{ !cancelled() && inputs.from_build != true }}
     steps:
+      - name: Check test results
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
       - name: Slack Notification
+        if: ${{ !cancelled() }}
         uses: shiguredo/github-actions/.github/actions/slack-notify@main
         with:
-          status: ${{ (contains(needs.*.result, 'failure')) && 'failure' || 'success' }}
+          status: ${{ job.status }}
           slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
           slack_channel: sora-python-sdk
           notify_mode: failure_and_fixed

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -244,16 +244,17 @@ jobs:
         env:
           UV_NO_SYNC: 1
 
-  slack_notify_failed:
+  slack_notify:
     needs: [e2e_test]
-    runs-on: ubuntu-24.04
-    if: failure() && inputs.from_build != true
+    runs-on: ubuntu-slim
+    if: ${{ !cancelled() && inputs.from_build != true }}
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: shiguredo/github-actions/.github/actions/slack-notify@main
+        with:
+          status: ${{ (contains(needs.*.result, 'failure')) && 'failure' || 'success' }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: sora-python-sdk
+          notify_mode: failure_and_fixed
         env:
-          SLACK_CHANNEL: sora-python-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: "FAILED"
-          SLACK_ICON_EMOJI: ":japanese_ogre:"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -249,11 +249,7 @@ jobs:
     runs-on: ubuntu-slim
     if: ${{ !cancelled() && inputs.from_build != true }}
     steps:
-      - name: Check test results
-        if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
       - name: Slack Notification
-        if: ${{ !cancelled() }}
         uses: shiguredo/github-actions/.github/actions/slack-notify@main
         with:
           status: ${{ job.status }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,11 @@
   - CMAKE_VERSION を `4.2.1` に上げる
   - @torikizi
 
+### misc
+
+- [UPDATE] Slack 通知を `rtCamp/action-slack-notify` から `shiguredo/github-actions/slack-notify` に切り替える
+  - @voluntas
+
 ## 2025.5.2
 
 **リリース日**: 2025-12-22


### PR DESCRIPTION
## Summary
- Slack 通知を `rtCamp/action-slack-notify@v2` から `shiguredo/github-actions/.github/actions/slack-notify@main` に切り替える
- `notify_mode: failure_and_fixed` により failure と fixed (前回失敗→今回成功) のみ通知する
- コメントアウトされていた `slack_notify_succeeded` ジョブを削除する
- dependabot から `rtCamp/action-slack-notify` の依存を削除する

## 変更対象
- `build.yml`: ビルド通知、publish_wheel 通知、create-release 通知
- `e2e-test.yml`: E2E テスト通知
- `dependabot.yml`: rtCamp 依存の削除
