### PR TITLE
ruff lint で I (isort) と UP (pyupgrade) を有効化する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,8 @@
 
 - [UPDATE] Slack 通知を `rtCamp/action-slack-notify` から `shiguredo/github-actions/slack-notify` に切り替える
   - @voluntas
+- [UPDATE] `pyproject.toml` の `[tool.ruff.lint]` に `extend-select = ["I", "UP"]` を追加する
+  - @voluntas
 
 ## 2025.5.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,7 +37,7 @@
 
 - [UPDATE] Slack 通知を `rtCamp/action-slack-notify` から `shiguredo/github-actions/slack-notify` に切り替える
   - @voluntas
-- [UPDATE] `pyproject.toml` の `[tool.ruff.lint]` に `extend-select = ["I", "UP"]` を追加する
+- [UPDATE] `pyproject.toml` の `[tool.ruff.lint]` に `extend-select = ["I", "UP", "PT"]` を追加する
   - @voluntas
 
 ## 2025.5.2

--- a/buildbase.py
+++ b/buildbase.py
@@ -37,13 +37,13 @@ import subprocess
 import tarfile
 import urllib.parse
 import zipfile
-from typing import Dict, List, NamedTuple, Optional
+from typing import NamedTuple
 
 if platform.system() == "Windows":
     import winreg
 
 
-class ChangeDirectory(object):
+class ChangeDirectory:
     def __init__(self, cwd):
         self._cwd = cwd
 
@@ -146,9 +146,9 @@ def add_path(path: str, is_after=False):
 
 def download(
     url: str,
-    output_dir: Optional[str] = None,
-    filename: Optional[str] = None,
-    expected_sha256: Optional[str] = None,
+    output_dir: str | None = None,
+    filename: str | None = None,
+    expected_sha256: str | None = None,
 ) -> str:
     if filename is None:
         output_path = urllib.parse.urlparse(url).path.split("/")[-1]
@@ -220,7 +220,7 @@ def verify_sha256(file_path: str, expected_sha256: str):
         logging.info(f"SHA256 hash verified successfully for {file_path}")
 
 
-def read_version_file(path: str) -> Dict[str, str]:
+def read_version_file(path: str) -> dict[str, str]:
     versions = {}
 
     lines = open(path, encoding="utf-8").readlines()
@@ -274,7 +274,7 @@ def versioned(func):
 #
 # 単一のディレクトリに格納されている場合はそのディレクトリ名を返す。
 # そうでない場合は None を返す。
-def _is_single_dir(infos, get_name, is_dir) -> Optional[str]:
+def _is_single_dir(infos, get_name, is_dir) -> str | None:
     # tarfile: ['path', 'path/to', 'path/to/file.txt']
     # zipfile: ['path/', 'path/to/', 'path/to/file.txt']
     # どちらも / 区切りだが、ディレクトリの場合、後ろに / が付くかどうかが違う
@@ -297,11 +297,11 @@ def _is_single_dir(infos, get_name, is_dir) -> Optional[str]:
     return dirname
 
 
-def is_single_dir_tar(tar: tarfile.TarFile) -> Optional[str]:
+def is_single_dir_tar(tar: tarfile.TarFile) -> str | None:
     return _is_single_dir(tar.getmembers(), lambda t: t.name, lambda t: t.isdir())
 
 
-def is_single_dir_zip(zip: zipfile.ZipFile) -> Optional[str]:
+def is_single_dir_zip(zip: zipfile.ZipFile) -> str | None:
     return _is_single_dir(zip.infolist(), lambda z: z.filename, lambda z: z.is_dir())
 
 
@@ -317,7 +317,7 @@ def _extractzip(z: zipfile.ZipFile, path: str):
         mod = info.external_attr >> 16
         if (mod & 0o120000) == 0o120000:
             # シンボリックリンク
-            with open(filepath, "r", encoding="utf-8") as f:
+            with open(filepath, encoding="utf-8") as f:
                 src = f.read()
             os.remove(filepath)
             with cd(os.path.dirname(filepath)):
@@ -350,7 +350,7 @@ def _extractzip(z: zipfile.ZipFile, path: str):
 # - out/libsora/libsora-1.23/file2
 # - out/libsora/LICENSE
 # が出力される。
-def extract(file: str, output_dir: str, output_dirname: str, filetype: Optional[str] = None):
+def extract(file: str, output_dir: str, output_dirname: str, filetype: str | None = None):
     path = os.path.join(output_dir, output_dirname)
     logging.info(f"Extract {file} to {path}")
     if (
@@ -552,7 +552,7 @@ def install_file_ifexists(src: str, dst: str):
 def replace_vcproj_static_runtime(project_file: str):
     # なぜか MSVC_STATIC_RUNTIME が効かずに DLL ランタイムを使ってしまうので
     # 生成されたプロジェクトに対して静的ランタイムを使うように変更する
-    s = open(project_file, "r", encoding="utf-8").read()
+    s = open(project_file, encoding="utf-8").read()
     s = s.replace("MultiThreadedDLL", "MultiThreaded")
     s = s.replace("MultiThreadedDebugDLL", "MultiThreadedDebug")
     open(project_file, "w", encoding="utf-8").write(s)
@@ -617,7 +617,7 @@ class WebrtcInfo(NamedTuple):
     version_file: str
     deps_file: str
     webrtc_include_dir: str
-    webrtc_source_dir: Optional[str]
+    webrtc_source_dir: str | None
     webrtc_library_dir: str
     webrtc_jar_file: str
     clang_dir: str
@@ -626,7 +626,7 @@ class WebrtcInfo(NamedTuple):
 
 
 def get_webrtc_info(
-    platform: str, local_webrtc_build_dir: Optional[str], install_dir: str, debug: bool
+    platform: str, local_webrtc_build_dir: str | None, install_dir: str, debug: bool
 ) -> WebrtcInfo:
     webrtc_install_dir = os.path.join(install_dir, "webrtc")
 
@@ -679,7 +679,7 @@ def install_boost(
     install_dir,
     sora_version,
     platform: str,
-    expected_sha256: Optional[str] = None,
+    expected_sha256: str | None = None,
 ):
     win = platform.startswith("windows_")
     filename = (
@@ -756,7 +756,7 @@ index 54a6ced32..4bb3810b3 100644
              local req = "-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64" ;
              local prop = "-property installationPath" ;
              local limit ;
- 
+
 -            if $(version) = 14.3
 +            if $(version) = 14.4
 +            {
@@ -768,12 +768,12 @@ index 54a6ced32..4bb3810b3 100644
              }
 @@ -2174,7 +2190,7 @@ for local arch in [ MATCH "^\\.cpus-on-(.*)" : [ VARNAMES $(__name__) ] ]
                       armv7 armv7s ;
- 
+
  # Known toolset versions, in order of preference.
 -.known-versions = 14.3 14.2 14.1 14.0 12.0 11.0 10.0 10.0express 9.0 9.0express 8.0 8.0express 7.1
 +.known-versions = 14.4 14.3 14.2 14.1 14.0 12.0 11.0 10.0 10.0express 9.0 9.0express 8.0 8.0express 7.1
      7.1toolkit 7.0 6.0 ;
- 
+
  # Version aliases.
 @@ -2226,6 +2242,11 @@ for local arch in [ MATCH "^\\.cpus-on-(.*)" : [ VARNAMES $(__name__) ] ]
      "Microsoft Visual Studio/2022/*/VC/Tools/MSVC/*/bin/Host*/*"
@@ -784,7 +784,7 @@ index 54a6ced32..4bb3810b3 100644
 +    "Microsoft Visual Studio/2022/*/VC/Tools/MSVC/*/bin/Host*/*"
 +    ;
 +.version-14.4-env = VS170COMNTOOLS ProgramFiles ProgramFiles(x86) ;
- 
+
  # Auto-detect all the available msvc installations on the system.
  auto-detect-toolset-versions ;
 """
@@ -798,9 +798,9 @@ def build_and_install_boost(
     install_dir,
     debug: bool,
     cxx: str,
-    cflags: List[str],
-    cxxflags: List[str],
-    linkflags: List[str],
+    cflags: list[str],
+    cxxflags: list[str],
+    linkflags: list[str],
     toolset,
     visibility,
     target_os,
@@ -810,7 +810,7 @@ def build_and_install_boost(
     address_model="64",
     runtime_link=None,
     android_build_platform="linux-x86_64",
-    expected_sha256: Optional[str] = None,
+    expected_sha256: str | None = None,
 ):
     version_underscore = version.replace(".", "_")
 
@@ -1036,9 +1036,9 @@ def install_sora_and_deps(
 def build_sora(
     platform: str,
     local_sora_cpp_sdk_dir: str,
-    local_sora_cpp_sdk_args: List[str],
+    local_sora_cpp_sdk_args: list[str],
     debug: bool,
-    local_webrtc_build_dir: Optional[str],
+    local_webrtc_build_dir: str | None,
 ):
     if debug and "--debug" not in local_sora_cpp_sdk_args:
         local_sora_cpp_sdk_args = ["--debug", *local_sora_cpp_sdk_args]
@@ -1059,7 +1059,7 @@ class SoraInfo(NamedTuple):
 
 
 def get_sora_info(
-    platform: str, local_sora_cpp_sdk_dir: Optional[str], install_dir: str, debug: bool
+    platform: str, local_sora_cpp_sdk_dir: str | None, install_dir: str, debug: bool
 ) -> SoraInfo:
     if local_sora_cpp_sdk_dir is not None:
         configuration = "debug" if debug else "release"
@@ -1251,7 +1251,7 @@ def install_cmake(version, source_dir, install_dir, platform: str, ext):
 
 @versioned
 def install_sdl2(
-    version, source_dir, build_dir, install_dir, debug: bool, platform: str, cmake_args: List[str]
+    version, source_dir, build_dir, install_dir, debug: bool, platform: str, cmake_args: list[str]
 ):
     url = (
         f"https://github.com/libsdl-org/SDL/releases/download/release-{version}/SDL2-{version}.zip"
@@ -1361,7 +1361,7 @@ def install_sdl2(
 
 @versioned
 def install_sdl3(
-    version, source_dir, build_dir, install_dir, debug: bool, platform: str, cmake_args: List[str]
+    version, source_dir, build_dir, install_dir, debug: bool, platform: str, cmake_args: list[str]
 ):
     url = f"https://github.com/libsdl-org/SDL/releases/download/release-{version}/SDL3-{version}.tar.gz"
     path = download(url, source_dir)
@@ -1541,7 +1541,7 @@ def install_blend2d_official(
     build_dir,
     install_dir,
     cmake_args,
-    expected_sha256: Optional[str] = None,
+    expected_sha256: str | None = None,
 ):
     rm_rf(os.path.join(source_dir, "blend2d"))
     rm_rf(os.path.join(build_dir, "blend2d"))
@@ -1768,9 +1768,9 @@ index 6464e200f..c7bc417a1 100644
 --- a/third_party/boringssl-with-bazel/CMakeLists.txt
 +++ b/third_party/boringssl-with-bazel/CMakeLists.txt
 @@ -543,30 +543,6 @@ add_library(
- 
+
  target_link_libraries(ssl crypto)
- 
+
 -add_executable(
 -  bssl
 -
@@ -1805,12 +1805,12 @@ index 7f1b69f..bcf5577 100644
 @@ -147,10 +147,7 @@ if(MINGW)
      set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
  endif(MINGW)
- 
+
 -add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
  add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
 -set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
 -set_target_properties(zlib PROPERTIES SOVERSION 1)
- 
+
  if(NOT CYGWIN)
      # This property causes shared libraries on Linux to have the full version
 @@ -160,22 +157,16 @@ if(NOT CYGWIN)
@@ -1819,7 +1819,7 @@ index 7f1b69f..bcf5577 100644
      # the DLL comes from the resource file win32/zlib1.rc
 -    set_target_properties(zlib PROPERTIES VERSION ${ZLIB_FULL_VERSION})
  endif()
- 
+
  if(UNIX)
      # On unix-like platforms the library is almost always called libz
 -   set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
@@ -1830,7 +1830,7 @@ index 7f1b69f..bcf5577 100644
      # Creates zlib1.dll when building shared library version
 -    set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
  endif()
- 
+
  if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
 -    install(TARGETS zlib zlibstatic
 +    install(TARGETS zlibstatic
@@ -1869,8 +1869,8 @@ def install_grpc(
     build_dir,
     install_dir,
     debug: bool,
-    cmake_args: List[str],
-    cmake_build_args: List[str] = [],
+    cmake_args: list[str],
+    cmake_build_args: list[str] = [],
 ):
     grpc_source_dir = os.path.join(source_dir, "grpc")
     grpc_build_dir = os.path.join(build_dir, "grpc")
@@ -1926,7 +1926,7 @@ index 38d63db..b97b175 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -795,7 +795,7 @@ endif()
- 
+
  if(INSTALL_ENABLED)
    install(TARGETS crypto ssl EXPORT OpenSSLTargets)
 -  install(TARGETS bssl)
@@ -1944,7 +1944,7 @@ def install_boringssl(
     build_dir: str,
     install_dir: str,
     configuration: str,
-    cmake_args: List[str],
+    cmake_args: list[str],
 ):
     boringssl_source_dir = os.path.join(source_dir, "boringssl")
     boringssl_build_dir = os.path.join(build_dir, "boringssl")
@@ -1974,7 +1974,7 @@ def install_boringssl(
 
 @versioned
 def install_opus(
-    version, source_dir, build_dir, install_dir, configuration: str, cmake_args: List[str]
+    version, source_dir, build_dir, install_dir, configuration: str, cmake_args: list[str]
 ):
     opus_source_dir = os.path.join(source_dir, "opus")
     opus_build_dir = os.path.join(build_dir, "opus")
@@ -2204,7 +2204,7 @@ def install_aom(version, source_dir, build_dir, install_dir, configuration, cmak
         cmd(["cmake", "--install", aom_build_dir])
 
 
-class PlatformTarget(object):
+class PlatformTarget:
     def __init__(self, os, osver, arch, extra=None):
         self.os = os
         self.osver = osver
@@ -2334,7 +2334,7 @@ def fix_clang_version(clang_dir, clang_version):
     )
 
 
-class Platform(object):
+class Platform:
     def _check(self, flag, error_message):
         if not flag:
             raise Exception(error_message)

--- a/canary.py
+++ b/canary.py
@@ -1,11 +1,10 @@
 import argparse
 import subprocess
-from typing import Optional
 
 
 # ファイルを読み込み、バージョンを更新
-def update_version(file_path: str, dry_run: bool) -> Optional[str]:
-    with open(file_path, "r", encoding="utf-8") as f:
+def update_version(file_path: str, dry_run: bool) -> str | None:
+    with open(file_path, encoding="utf-8") as f:
         current_version: str = f.read().strip()
 
     # バージョンが .devX を持っている場合の更新
@@ -86,7 +85,7 @@ def main() -> None:
     version_file_path: str = "VERSION"
 
     # バージョン更新
-    new_version: Optional[str] = update_version(version_file_path, args.dry_run)
+    new_version: str | None = update_version(version_file_path, args.dry_run)
 
     if not new_version:
         return  # ユーザーが確認をキャンセルした場合、処理を中断

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,6 @@ line-length = 100
 
 [tool.ruff.lint]
 extend-select = ["I", "UP", "PT"]
-ignore = [
-    "PT015",
-    "PT016",
-    "PT018",
-]
 
 [tool.ty.src]
 include = ["src", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,12 @@ target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]
-extend-select = ["I", "UP"]
+extend-select = ["I", "UP", "PT"]
+ignore = [
+    "PT015",
+    "PT016",
+    "PT018",
+]
 
 [tool.ty.src]
 include = ["src", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ xfail_strict = true
 target-version = "py312"
 line-length = 100
 
+[tool.ruff.lint]
+extend-select = ["I", "UP"]
+
 [tool.ty.src]
 include = ["src", "tests"]
 

--- a/run.py
+++ b/run.py
@@ -7,7 +7,6 @@ import os
 import shlex
 import shutil
 import sys
-from typing import List, Optional
 
 from buildbase import (
     Platform,
@@ -43,10 +42,10 @@ def install_deps(
     build_dir,
     install_dir,
     debug,
-    local_webrtc_build_dir: Optional[str],
-    local_webrtc_build_args: List[str],
-    local_sora_cpp_sdk_dir: Optional[str],
-    local_sora_cpp_sdk_args: List[str],
+    local_webrtc_build_dir: str | None,
+    local_webrtc_build_args: list[str],
+    local_sora_cpp_sdk_dir: str | None,
+    local_sora_cpp_sdk_args: list[str],
 ):
     version = read_version_file("DEPS")
 
@@ -185,7 +184,7 @@ AVAILABLE_TARGETS = [
 ]
 
 
-def _find_clang_binary(name: str) -> Optional[str]:
+def _find_clang_binary(name: str) -> str | None:
     if shutil.which(name) is not None:
         return name
     else:
@@ -223,10 +222,10 @@ def _build(
     target: str,
     debug: bool,
     relwithdebinfo: bool,
-    local_webrtc_build_dir: Optional[str],
-    local_webrtc_build_args: List[str],
-    local_sora_cpp_sdk_dir: Optional[str],
-    local_sora_cpp_sdk_args: List[str],
+    local_webrtc_build_dir: str | None,
+    local_webrtc_build_args: list[str],
+    local_sora_cpp_sdk_dir: str | None,
+    local_sora_cpp_sdk_args: list[str],
 ):
     platform = _get_platform(target)
 
@@ -425,7 +424,7 @@ def _build(
 
 
 def _format(
-    clang_format_path: Optional[str] = None,
+    clang_format_path: str | None = None,
     skip_clang_format: bool = False,
     skip_ruff: bool = False,
 ):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from buildbase import PlatformTarget, cd, get_build_platform  # noqa: E402
 
 
 def run_setup(build_platform, target_platform):
-    with open(os.path.join(BASE_DIR, "VERSION"), "r") as f:
+    with open(os.path.join(BASE_DIR, "VERSION")) as f:
         version = f.read().strip()
 
     build_profile = os.getenv("BUILD_PROFILE")

--- a/src/sora_sdk/__init__.py
+++ b/src/sora_sdk/__init__.py
@@ -3,7 +3,7 @@ from .sora_sdk_ext import *  # noqa: F401,F403
 # インストールされたパッケージの場合は importlib.metadata から取得
 # 開発環境の場合は VERSION ファイルから取得
 try:
-    from importlib.metadata import version, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, version
 
     try:
         __version__ = version("sora_sdk")
@@ -15,7 +15,7 @@ try:
             os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "VERSION"
         )
         if os.path.exists(_version_file):
-            with open(_version_file, "r") as f:
+            with open(_version_file) as f:
                 __version__ = f.read().strip()
         else:
             __version__ = "unknown"

--- a/tests/client.py
+++ b/tests/client.py
@@ -2,9 +2,10 @@ import json
 import queue
 import threading
 import time
+from collections.abc import Callable
 from enum import Enum
 from threading import Event
-from typing import Any, Callable, Optional
+from typing import Any
 
 import numpy
 from conftest import Settings
@@ -42,27 +43,27 @@ class SoraClient:
         self,
         settings: Settings,
         role: SoraRole,
-        simulcast: Optional[bool] = None,
-        spotlight: Optional[bool] = None,
+        simulcast: bool | None = None,
+        spotlight: bool | None = None,
         metadata: dict[str, str] | None = None,
         jwt_private_claims: dict[str, Any] | None = None,
-        audio: Optional[bool] = None,
-        audio_codec_type: Optional[str] = None,
-        audio_opus_params: Optional[dict[str, Any]] = None,
-        video: Optional[bool] = None,
-        video_codec_type: Optional[str] = None,
-        video_bit_rate: Optional[int] = None,
-        data_channel_signaling: Optional[bool] = None,
-        ignore_disconnect_websocket: Optional[bool] = None,
-        data_channels: Optional[list[dict[str, Any]]] = None,
-        forwarding_filter: Optional[dict[str, Any]] = None,
-        forwarding_filters: Optional[list[dict[str, Any]]] = None,
-        client_key: Optional[bytes] = None,
-        client_cert: Optional[bytes] = None,
-        ca_cert: Optional[bytes] = None,
-        degradation_preference: Optional[SoraDegradationPreference] = None,
-        user_agent: Optional[str] = None,
-        video_codec_preference: Optional[SoraVideoCodecPreference] = None,
+        audio: bool | None = None,
+        audio_codec_type: str | None = None,
+        audio_opus_params: dict[str, Any] | None = None,
+        video: bool | None = None,
+        video_codec_type: str | None = None,
+        video_bit_rate: int | None = None,
+        data_channel_signaling: bool | None = None,
+        ignore_disconnect_websocket: bool | None = None,
+        data_channels: list[dict[str, Any]] | None = None,
+        forwarding_filter: dict[str, Any] | None = None,
+        forwarding_filters: list[dict[str, Any]] | None = None,
+        client_key: bytes | None = None,
+        client_cert: bytes | None = None,
+        ca_cert: bytes | None = None,
+        degradation_preference: SoraDegradationPreference | None = None,
+        user_agent: str | None = None,
+        video_codec_preference: SoraVideoCodecPreference | None = None,
         audio_channels: int = 1,
         audio_sample_rate: int = 16000,
         audio_output_channels: int = 1,
@@ -71,9 +72,9 @@ class SoraClient:
         video_height: int = 480,
         video_frame_rate: int = 30,
         libcamera: bool = False,
-        libcamera_controls: Optional[list[tuple[str, str]]] = None,
+        libcamera_controls: list[tuple[str, str]] | None = None,
         native_frame_output: bool = False,
-        force_i420_conversion: Optional[bool] = None,
+        force_i420_conversion: bool | None = None,
     ):
         self._signaling_urls = settings.signaling_urls
         self._role = role.value
@@ -124,16 +125,16 @@ class SoraClient:
             force_i420_conversion=force_i420_conversion,
         )
 
-        self._fake_audio_thread: Optional[threading.Thread] = None
-        self._fake_video_thread: Optional[threading.Thread] = None
+        self._fake_audio_thread: threading.Thread | None = None
+        self._fake_video_thread: threading.Thread | None = None
 
-        self._audio_source: Optional[SoraAudioSource] = None
+        self._audio_source: SoraAudioSource | None = None
         if self._audio:
             self._audio_source = self._sora.create_audio_source(
                 self._audio_channels, self._audio_sample_rate
             )
 
-        self._video_source: Optional[SoraVideoSource | SoraTrackInterface] = None
+        self._video_source: SoraVideoSource | SoraTrackInterface | None = None
         if libcamera and self._video:
             self._video_source = self._sora.create_libcamera_source(
                 width=self._video_width,
@@ -145,8 +146,8 @@ class SoraClient:
         elif self._video:
             self._video_source = self._sora.create_video_source()
 
-        self._audio_sink: Optional[SoraAudioSink] = None
-        self._video_sink: Optional[SoraVideoSink] = None
+        self._audio_sink: SoraAudioSink | None = None
+        self._video_sink: SoraVideoSink | None = None
 
         self._data_channel_ready_events: dict[str, Event] = {}
         self._messaging_recv_queues: dict[str, queue.Queue] = {}
@@ -178,39 +179,39 @@ class SoraClient:
         )
 
         # "type": "offer" のパラメータ
-        self._offer_data_channel_signaling: Optional[bool] = None
-        self._offer_data_channels: Optional[list[dict[str, Any]]] = None
+        self._offer_data_channel_signaling: bool | None = None
+        self._offer_data_channels: list[dict[str, Any]] | None = None
 
         # "type": "switched" のパラメータ
-        self._ignore_disconnect_websocket: Optional[bool] = None
+        self._ignore_disconnect_websocket: bool | None = None
 
-        self._connection_id: Optional[str] = None
+        self._connection_id: str | None = None
 
         # state
         self._connected: Event = Event()
         self._switched: bool = False
         self._ws_close: bool = False
-        self._ws_close_code: Optional[int] = None
-        self._ws_close_reason: Optional[str] = None
+        self._ws_close_code: int | None = None
+        self._ws_close_reason: str | None = None
         self._disconnected: Event = Event()
 
         self._notify_queue: queue.Queue = queue.Queue()
 
-        self._disconnect_error_code: Optional[int] = None
-        self._disconnect_error_message: Optional[str] = None
+        self._disconnect_error_code: int | None = None
+        self._disconnect_error_message: str | None = None
 
         self._default_connection_timeout_s: float = 10.0
 
         # signaling message
-        self._connect_message: Optional[dict[str, Any]] = None
-        self._redirect_message: Optional[dict[str, Any]] = None
-        self._offer_message: Optional[dict[str, Any]] = None
-        self._answer_message: Optional[dict[str, Any]] = None
+        self._connect_message: dict[str, Any] | None = None
+        self._redirect_message: dict[str, Any] | None = None
+        self._offer_message: dict[str, Any] | None = None
+        self._answer_message: dict[str, Any] | None = None
         self._candidate_messages: list[dict[str, Any]] = []
         self._re_offer_messages: list[dict[str, Any]] = []
         self._re_answer_messages: list[dict[str, Any]] = []
-        self._disconnect_message: Optional[dict[str, Any]] = None
-        self._close_message: Optional[dict[str, Any]] = None
+        self._disconnect_message: dict[str, Any] | None = None
+        self._close_message: dict[str, Any] | None = None
 
         # callback
         self._connection.on_signaling_message = self._on_signaling_message
@@ -289,23 +290,23 @@ class SoraClient:
         return self._metadata
 
     @property
-    def connection_id(self) -> Optional[str]:
+    def connection_id(self) -> str | None:
         return self._connection_id
 
     @property
-    def connect_message(self) -> Optional[dict[str, Any]]:
+    def connect_message(self) -> dict[str, Any] | None:
         return self._connect_message
 
     @property
-    def redirect_message(self) -> Optional[dict[str, Any]]:
+    def redirect_message(self) -> dict[str, Any] | None:
         return self._redirect_message
 
     @property
-    def offer_message(self) -> Optional[dict[str, Any]]:
+    def offer_message(self) -> dict[str, Any] | None:
         return self._offer_message
 
     @property
-    def answer_message(self) -> Optional[dict[str, Any]]:
+    def answer_message(self) -> dict[str, Any] | None:
         return self._answer_message
 
     @property
@@ -321,11 +322,11 @@ class SoraClient:
         return self._re_answer_messages
 
     @property
-    def disconnect_message(self) -> Optional[dict[str, Any]]:
+    def disconnect_message(self) -> dict[str, Any] | None:
         return self._disconnect_message
 
     @property
-    def close_message(self) -> Optional[dict[str, Any]]:
+    def close_message(self) -> dict[str, Any] | None:
         return self._close_message
 
     @property
@@ -337,7 +338,7 @@ class SoraClient:
         return self._switched
 
     @property
-    def ignore_disconnect_websocket(self) -> Optional[bool]:
+    def ignore_disconnect_websocket(self) -> bool | None:
         return self._ignore_disconnect_websocket
 
     @property
@@ -345,19 +346,19 @@ class SoraClient:
         return self._ws_close
 
     @property
-    def ws_close_code(self) -> Optional[int]:
+    def ws_close_code(self) -> int | None:
         return self._ws_close_code
 
     @property
-    def ws_close_reason(self) -> Optional[str]:
+    def ws_close_reason(self) -> str | None:
         return self._ws_close_reason
 
     @property
-    def disconnect_code(self) -> Optional[int]:
+    def disconnect_code(self) -> int | None:
         return self._disconnect_code
 
     @property
-    def disconnect_reason(self) -> Optional[str]:
+    def disconnect_reason(self) -> str | None:
         return self._disconnect_reason
 
     def _fake_audio_loop(self):
@@ -506,7 +507,7 @@ class SoraClient:
             self._video_sink = SoraVideoSink(track)
             self._video_sink.on_frame = self._on_video_frame
 
-    def wait_notify(self, pred: Callable[[dict], bool], timeout: Optional[int] = 5):
+    def wait_notify(self, pred: Callable[[dict], bool], timeout: int | None = 5):
         while True:
             notify = self._notify_queue.get(block=True, timeout=timeout)
             if pred(notify):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ class Settings:
         if not env_path.exists():
             return
 
-        with open(env_path, "r", encoding="utf-8") as f:
+        with open(env_path, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line or line.startswith("#"):

--- a/tests/test_encoded_transform.py
+++ b/tests/test_encoded_transform.py
@@ -2,7 +2,7 @@ import json
 import threading
 import time
 from threading import Event
-from typing import Any, Optional
+from typing import Any
 
 import numpy
 from conftest import Settings
@@ -58,15 +58,15 @@ class SendonlyEncodedTransform:
 
         self._sora = Sora()
 
-        self._fake_audio_thread: Optional[threading.Thread] = None
-        self._fake_video_thread: Optional[threading.Thread] = None
+        self._fake_audio_thread: threading.Thread | None = None
+        self._fake_video_thread: threading.Thread | None = None
 
-        self._audio_source: Optional[SoraAudioSource] = None
+        self._audio_source: SoraAudioSource | None = None
         self._audio_source = self._sora.create_audio_source(
             self._audio_channels, self._audio_sample_rate
         )
 
-        self._video_source: Optional[SoraVideoSource] = None
+        self._video_source: SoraVideoSource | None = None
         self._video_source = self._sora.create_video_source()
 
         # Audio 向けの Encoded Transformer

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -31,8 +31,8 @@ def test_messaging(settings):
     assert messaging_sendonly.switched
     assert messaging_recvonly.switched
 
-    message1 = "spam".encode("utf-8")
-    message2 = "はむ".encode("utf-8")
+    message1 = b"spam"
+    message2 = "はむ".encode()
 
     messaging_sendonly.send_message(messaging_label, message1)
     messaging_sendonly.send_message(messaging_label, message2)

--- a/tests/test_messaging_header.py
+++ b/tests/test_messaging_header.py
@@ -37,8 +37,8 @@ def test_messaging_header(settings):
     assert messaging_sendonly.switched
     assert messaging_recvonly.switched
 
-    message1 = "spam".encode("utf-8")
-    message2 = "はむ".encode("utf-8")
+    message1 = b"spam"
+    message2 = "はむ".encode()
 
     messaging_sendonly.send_message(messaging_label, message1)
     messaging_sendonly.send_message(messaging_label, message2)

--- a/tests/test_openh264.py
+++ b/tests/test_openh264.py
@@ -29,7 +29,8 @@ def test_capability(settings):
             has_internal = True
         if engine.name == SoraVideoCodecImplementation.CISCO_OPENH264:
             has_openh264 = True
-    assert has_internal and has_openh264
+    assert has_internal
+    assert has_openh264
 
 
 def test_preference(settings):

--- a/tests/test_sendonly_recvonly.py
+++ b/tests/test_sendonly_recvonly.py
@@ -49,7 +49,7 @@ def test_sendonly_recvonly_audio(settings):
 
 
 @pytest.mark.parametrize(
-    "video_codec_type, encoder_implementation, decoder_implementation",
+    ("video_codec_type", "encoder_implementation", "decoder_implementation"),
     [
         ("VP8", "libvpx", "libvpx"),
         ("VP9", "libvpx", "libvpx"),

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,4 +1,5 @@
 import os
+
 import sora_sdk
 
 
@@ -10,7 +11,7 @@ def test_version():
 
     # VERSION ファイルの内容と一致することを確認
     version_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), "VERSION")
-    with open(version_file, "r") as f:
+    with open(version_file) as f:
         expected_version = f.read().strip()
 
     assert sora_sdk.__version__ == expected_version


### PR DESCRIPTION
## Summary

- `pyproject.toml` の `[tool.ruff.lint]` に `extend-select = ["I", "UP"]` を追加
- 検出された 121 件を `ruff check --fix` で自動修正
  - `typing.List` / `Dict` / `Optional` などを組み込み型 (`list` / `dict` / `X | None`) に置換
  - import 整列 (I001)
  - 不要な `.encode("utf-8")` / `open(..., "r")` の `"r"` を削除

## Test plan

- [x] `uv run ruff check .` がパスすること
- [x] `uv run ruff format --check .` がパスすること
- [x] pre-commit フック (`ruff check` / `ruff format` / `ty check`) が全て通ること