### PR TITLE
0030 ubuntu-24.04_armv8 platform の cross-compile wheel ビルドを sysroot.py 経路で追加する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,10 +118,9 @@ jobs:
         exclude:
           - platform: { name: ubuntu-22.04_x86_64 }
           - platform: { name: ubuntu-22.04_armv8 }
-          - platform: { name: ubuntu-24.04_armv8 }
           - platform: { name: raspberry-pi-os_armv8 }
     runs-on: ${{ matrix.platform.runs_on }}
-    timeout-minutes: 15
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -144,6 +143,49 @@ jobs:
 
       - if: ${{ matrix.platform.arch == 'x86_64' }}
         run: uv build --wheel
+
+      # cross-compile (ubuntu-24.04_armv8) 用 wheel ビルド。
+      # SORA_PYTHON_SDK_SYSROOT_DIR は cmake/toolchains/aarch64-linux-gnu.cmake で
+      # CMAKE_SYSROOT に渡される (toolchain 評価時点で path 存在が必要なため事前に mkdir)。
+      # sysroot の中身は fetch_deps.cmake 内 _sora_fetch_rootfs (sysroot.py) で構築する。
+      # _PYTHON_HOST_PLATFORM=linux-aarch64 で wheel タグの platform 部分を linux_aarch64 に確定する。
+      # CMAKE_ARGS の 4 値は cmake configure 開始時に必要なため、 pyproject.toml の override ではなく
+      # 環境変数経由で cmake コマンドラインに直接渡す。 NB_SUFFIX と SORA_GEN_PYI は CMakeLists.txt で確定する。
+      - name: Build wheel (cross ubuntu-24.04_armv8)
+        if: matrix.platform.target == 'ubuntu-24.04_armv8'
+        env:
+          SORA_PYTHON_SDK_PLATFORM: ubuntu-24.04_armv8
+          SORA_PYTHON_SDK_SYSROOT_DIR: ${{ github.workspace }}/_deps/ubuntu-24.04_armv8/rootfs
+          _PYTHON_HOST_PLATFORM: linux-aarch64
+          CMAKE_ARGS: >-
+            -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/aarch64-linux-gnu.cmake
+            -DSORA_PYTHON_SDK_PLATFORM=ubuntu-24.04_armv8
+            -DCMAKE_C_COMPILER_WORKS=TRUE
+            -DCMAKE_CXX_COMPILER_WORKS=TRUE
+        run: |
+          mkdir -p "${SORA_PYTHON_SDK_SYSROOT_DIR}"
+          uv build --wheel
+
+      # 生成した wheel が確かに linux_aarch64 / aarch64 ELF であることを 4 段で検証する。
+      - name: Verify wheel architecture (cross ubuntu-24.04_armv8)
+        if: matrix.platform.target == 'ubuntu-24.04_armv8'
+        shell: bash
+        run: |
+          set -eux
+          shopt -s nullglob
+          ls dist/
+          WHEELS=(dist/sora_sdk-*-cp*-linux_aarch64.whl)
+          [[ ${#WHEELS[@]} -eq 1 ]] || { echo "ERROR: expected 1 linux_aarch64 wheel, got ${#WHEELS[@]}"; ls dist/; exit 1; }
+          WHL="${WHEELS[0]}"
+          WHL_DIR=$(mktemp -d)
+          unzip -o "$WHL" -d "$WHL_DIR"
+          SO_FILES=("$WHL_DIR/sora_sdk/sora_sdk_ext."*.so)
+          [[ ${#SO_FILES[@]} -eq 1 ]] || { echo "ERROR: expected 1 .so, got ${#SO_FILES[@]}"; ls "$WHL_DIR/sora_sdk/"; exit 1; }
+          SO_FILE="${SO_FILES[0]}"
+          [[ "$SO_FILE" == *"-aarch64-linux-gnu.so" ]] || { echo "ERROR: .so suffix is not -aarch64-linux-gnu: $SO_FILE"; exit 1; }
+          FILE_OUT=$(file "$SO_FILE")
+          echo "$FILE_OUT"
+          grep -qE 'ELF 64-bit LSB.*ARM aarch64' <<< "$FILE_OUT" || { echo "ERROR: .so is not aarch64 ELF; actual: $FILE_OUT"; exit 1; }
 
       - name: Upload Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,10 +19,14 @@
   - @voluntas
 - [CHANGE] cross-compile 用 sysroot 構築から multistrap を廃止する
   - multistrap は Debian/Ubuntu 上流のメンテが停滞しており、 Ubuntu 26.04 で配布終了見込みのため
-  - armv8 系 cross-compile wheel は CI で生成されない (元から matrix exclude 済)
   - @voluntas
 - [ADD] cross-compile 用 sysroot 構築スクリプト sysroot.py を追加する
   - ubuntu-22.04_armv8 / ubuntu-24.04_armv8 / ubuntu-22.04_armv8_jetson / raspberry-pi-os_armv8 向けの設定を同梱する
+  - @voluntas
+- [ADD] ubuntu-24.04_armv8 platform の cross-compile wheel ビルドを sysroot.py 経路で追加する
+  - multistrap 廃止に伴い停止していた cross-compile wheel ビルドを scikit-build-core (cmake) → `_sora_fetch_rootfs` → sysroot.py 経路で再開
+  - wheel タグは `linux_aarch64` で artifact 化のみ。 manylinux タグ化と PyPI publish (`pip install sora_sdk` 経由でのインストール) は今後対応する
+  - ubuntu-24.04_armv8 のみ追加、 残り 3 platform (ubuntu-22.04_armv8 / raspberry-pi-os_armv8 / ubuntu-22.04_armv8_jetson) は今後対応する
   - @voluntas
 - [UPDATE] nanobind を `2.13.0` に上げる
   - ABI バージョン 19 から 20 への変更に伴い拡張の再コンパイルが必要

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,16 @@ list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
 set(TARGET_OS "" CACHE STRING "ビルド対象の動作する OS。\n有効な値は windows, macos, ubuntu, jetson, raspberry-pi-os")
 set(SORA_GEN_PYI ON CACHE BOOL ".pyi スタブを生成するかどうか")
 set(SORA_PYTHON_SDK_PLATFORM "" CACHE STRING "プラットフォーム識別子 (例: ubuntu-24.04_x86_64)")
+
+# cross-compile 時の nanobind 関連設定。
+# CMAKE_TOOLCHAIN_FILE / CMAKE_C_COMPILER_WORKS は project() 前評価のため CI step の CMAKE_ARGS 経由で渡すが、
+# NB_SUFFIX と SORA_GEN_PYI は nanobind_add_module 呼び出し前 (find_package(Python) 後) で間に合うため、
+# Python ABI 別に値を組み立てる責務を CMakeLists.txt 側で持つ。
+if(SORA_PYTHON_SDK_PLATFORM STREQUAL "ubuntu-24.04_armv8")
+  set(NB_SUFFIX ".cpython-${Python_VERSION_MAJOR}${Python_VERSION_MINOR}-aarch64-linux-gnu.so")
+  # cross-compile 時は host 上で aarch64 の .so を import できず nanobind_add_stub が必ず失敗するため OFF。
+  set(SORA_GEN_PYI OFF)
+endif()
 set(WEBRTC_INCLUDE_DIR "" CACHE PATH "WebRTC のインクルードディレクトリ")
 set(WEBRTC_LIBRARY_DIR "" CACHE PATH "WebRTC のライブラリディレクトリ")
 set(WEBRTC_LIBRARY_NAME "webrtc" CACHE STRING "WebRTC のライブラリ名")

--- a/cmake/scripts/fetch_deps.cmake
+++ b/cmake/scripts/fetch_deps.cmake
@@ -73,12 +73,12 @@ if(NOT SORA_PYTHON_SDK_PLATFORM)
 endif()
 
 # 許容リスト検証
-set(_SORA_ALLOWED_PLATFORMS "ubuntu-24.04_x86_64" "macos_arm64" "windows_x86_64")
+set(_SORA_ALLOWED_PLATFORMS "ubuntu-24.04_x86_64" "ubuntu-24.04_armv8" "macos_arm64" "windows_x86_64")
 list(FIND _SORA_ALLOWED_PLATFORMS "${SORA_PYTHON_SDK_PLATFORM}" _SORA_PLATFORM_INDEX)
 if(_SORA_PLATFORM_INDEX EQUAL -1)
   message(FATAL_ERROR
     "Unsupported SORA_PYTHON_SDK_PLATFORM='${SORA_PYTHON_SDK_PLATFORM}'. "
-    "Supported: ubuntu-24.04_x86_64, macos_arm64, windows_x86_64.")
+    "Supported: ubuntu-24.04_x86_64, ubuntu-24.04_armv8, macos_arm64, windows_x86_64.")
 endif()
 
 # 排他ロック取得（複数 Python ABI 並列ビルド時の _deps/<platform>/ 競合回避）
@@ -456,6 +456,30 @@ endif()
 # Windows では MSVC を使用するため LLVM 取得は不要
 if(NOT WIN32)
   _sora_fetch_llvm("${_PLATFORM_ROOT}/webrtc" "${_LLVM_ROOT}" "${_LLVM_STAMPS_ROOT}/llvm")
+endif()
+
+# cross 系 platform 用 sysroot 構築 (rootfs を _PLATFORM_ROOT/rootfs に展開)。
+# CMAKE_SYSROOT は toolchain ファイル経由で SORA_PYTHON_SDK_SYSROOT_DIR 環境変数から確定済。
+# ここでは rootfs ディレクトリの中身 (libc / libstdc++ / dev headers) を sysroot.py で構築する。
+if(SORA_PYTHON_SDK_PLATFORM STREQUAL "ubuntu-24.04_armv8")
+  set(_ROOTFS_DIR "${_PLATFORM_ROOT}/rootfs")
+  _sora_fetch_rootfs("${_ROOTFS_DIR}"
+    "${CMAKE_SOURCE_DIR}/sysroot/${SORA_PYTHON_SDK_PLATFORM}.json")
+  # CMAKE_SYSROOT と _ROOTFS_DIR が一致することを sanity check する。
+  # 比較前に file(REAL_PATH) で正規化して、 末尾スラッシュ / シンボリックリンク経由で誤検出しないようにする。
+  # 右辺は CMP0054 NEW (CMakeLists.txt) のもとで文字列リテラル扱いになるのを避けるため明示的に展開する。
+  if(NOT CMAKE_SYSROOT)
+    message(FATAL_ERROR
+      "CMAKE_SYSROOT is empty. "
+      "Set SORA_PYTHON_SDK_SYSROOT_DIR env var to '${_ROOTFS_DIR}' before running 'uv build --wheel'.")
+  endif()
+  file(REAL_PATH "${CMAKE_SYSROOT}" _SYSROOT_REAL)
+  file(REAL_PATH "${_ROOTFS_DIR}" _ROOTFS_REAL)
+  if(NOT "${_SYSROOT_REAL}" STREQUAL "${_ROOTFS_REAL}")
+    message(FATAL_ERROR
+      "CMAKE_SYSROOT (${CMAKE_SYSROOT}) does not match expected rootfs (${_ROOTFS_DIR}). "
+      "Set SORA_PYTHON_SDK_SYSROOT_DIR env var to '${_ROOTFS_DIR}' before running 'uv build --wheel'.")
+  endif()
 endif()
 
 # 出力契約 8 変数を CACHE PATH で確定

--- a/cmake/toolchains/aarch64-linux-gnu.cmake
+++ b/cmake/toolchains/aarch64-linux-gnu.cmake
@@ -1,0 +1,12 @@
+# aarch64-linux-gnu 用 cross-compile toolchain (Ubuntu / Raspberry Pi OS / Jetson 共通)。
+# CMAKE_SYSROOT は CMake 仕様で toolchain ファイル内でのみ設定可能。
+# sysroot path は CI step (もしくは開発者の uv build 起動時) に環境変数で渡す。
+# sysroot の中身は fetch_deps.cmake 内 _sora_fetch_rootfs で構築する。
+# CMAKE_C_COMPILER / CMAKE_CXX_COMPILER は fetch_deps.cmake で LLVM 同梱 clang に確定する。
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+set(CMAKE_C_COMPILER_TARGET aarch64-linux-gnu)
+set(CMAKE_CXX_COMPILER_TARGET aarch64-linux-gnu)
+if(DEFINED ENV{SORA_PYTHON_SDK_SYSROOT_DIR})
+  set(CMAKE_SYSROOT "$ENV{SORA_PYTHON_SDK_SYSROOT_DIR}")
+endif()

--- a/issues/closed/0030-add-ubuntu-24-04-armv8-cross-build.md
+++ b/issues/closed/0030-add-ubuntu-24-04-armv8-cross-build.md
@@ -2,7 +2,7 @@
 
 - Priority: High
 - Created: 2026-06-22
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-22
 - Model: Opus 4.7
 - Branch: feature/add-ubuntu-24-04-armv8-cross-build
 - Polished: 2026-06-22
@@ -317,15 +317,23 @@ cmake.define.SORA_GEN_PYI = "OFF"
 
 ## 解決方法
 
-1. `cmake/toolchains/aarch64-linux-gnu.cmake` を新規作成 (設計方針節の内容そのまま、 `set` 5 行 + if ブロック)
+1. `cmake/toolchains/aarch64-linux-gnu.cmake` を新規作成
+   - `CMAKE_SYSTEM_NAME` / `CMAKE_SYSTEM_PROCESSOR` / `CMAKE_C_COMPILER_TARGET` / `CMAKE_CXX_COMPILER_TARGET` を set
+   - `SORA_PYTHON_SDK_SYSROOT_DIR` 環境変数があれば `CMAKE_SYSROOT` に確定
 2. `cmake/scripts/fetch_deps.cmake` を改修
-   - `_SORA_ALLOWED_PLATFORMS` (76 行目) 拡張
-   - メインスクリプトの `_sora_fetch_llvm` を含む `if(NOT WIN32) ... endif()` ブロック (455-459 行) 直後、 `# 出力契約 8 変数を CACHE PATH で確定` (461 行) より前に cross 分岐追加 (`_sora_fetch_rootfs` 呼び出し + `CMAKE_SYSROOT` sanity check)
-3. `pyproject.toml` に Python 3.12 / 3.13 / 3.14 別の cross 用 `[[tool.scikit-build.overrides]]` を 3 件追加 (`if.env` は anchored regex、 `CMAKE_C_COMPILER_WORKS = "TRUE"` 含む)
-4. `.github/workflows/build.yml` の `exclude:` から `ubuntu-24.04_armv8` を削除、 `timeout-minutes` を `60` に変更、 `SORA_PYTHON_SDK_SYSROOT_DIR` を env で渡す cross build step + Verify step を追加
-5. `CHANGES.md` の `## develop` に `[ADD]` エントリを既存 sysroot.py `[ADD]` 直後に追加し、 0024 由来 `[CHANGE]` エントリの 2 行目を削除
-6. ローカル macOS で「ローカル macOS で実行可能な確認」 を実施
-7. PR を出して CI で動作検証。 「CI 上の反復確認」 に挙げた不足パッケージ追加を反復で push する
+   - `_SORA_ALLOWED_PLATFORMS` に `ubuntu-24.04_armv8` を追加 (エラーメッセージも同期)
+   - メインスクリプトの `_sora_fetch_llvm` 直後に cross 分岐を追加し、 `_sora_fetch_rootfs` で sysroot を構築
+   - sanity check は `file(REAL_PATH)` で両辺正規化したうえで `STREQUAL` 比較し、 末尾スラッシュ / シンボリックリンク差を吸収。 空 `CMAKE_SYSROOT` 検出時は明示的に `FATAL_ERROR`。 比較式の右辺は CMP0054 NEW のもとで文字列リテラル扱いされないよう明示的に `"${...}"` で展開
+3. **設計変更**: `pyproject.toml` の cross 用 `[[tool.scikit-build.overrides]]` は **0 件** とし、 CI step の `CMAKE_ARGS` 環境変数で `-DCMAKE_TOOLCHAIN_FILE` / `-DSORA_PYTHON_SDK_PLATFORM` / `-DCMAKE_C_COMPILER_WORKS=TRUE` / `-DCMAKE_CXX_COMPILER_WORKS=TRUE` を直接渡す経路に変更
+   - 元設計の Python ABI 別 override 3 件は、 cross platform を追加するたびに 3 倍に増えるため
+   - `NB_SUFFIX` / `SORA_GEN_PYI` は `CMakeLists.txt` の cross 分岐内 (`SORA_PYTHON_SDK_PLATFORM` 単独条件) で確定。 `NB_SUFFIX` は `Python_VERSION_MAJOR` / `Python_VERSION_MINOR` から組み立てる
+4. `.github/workflows/build.yml` の `build_ubuntu` を改修
+   - `exclude:` から `ubuntu-24.04_armv8` を 1 行削除
+   - `timeout-minutes` を 15 → 60 に引き上げ
+   - cross build step (env で `SORA_PYTHON_SDK_PLATFORM` / `SORA_PYTHON_SDK_SYSROOT_DIR` / `_PYTHON_HOST_PLATFORM` / `CMAKE_ARGS` を渡す) を追加
+   - Verify wheel architecture step (wheel 個数 / `.so` 個数 / `.so` suffix / ELF target の 4 段検証) を追加。 配列長判定は `[[ ... -eq ]]`、 unzip 先は `mktemp -d`、 ELF 検証は `grep -qE ... <<< "$FILE_OUT"` で fail 時のエラーメッセージを強化
+5. `CHANGES.md` の `## develop` に `[ADD]` エントリを既存 sysroot.py `[ADD]` 直後に追加し、 0024 由来 `[CHANGE]` エントリの 2 行目 (`armv8 系 cross-compile wheel は CI で生成されない (元から matrix exclude 済)`) を削除。 利用者向けに PyPI publish の影響 (`pip install sora_sdk` は未対応) を明示
+6. ローカル macOS で「ローカル macOS で実行可能な確認」 を実施 (`cmake -P cmake/toolchains/aarch64-linux-gnu.cmake` / `tomllib.load(pyproject.toml)` / `uv run ruff format --check` が pass、 prebuilt artifact 3 件の HTTP 200 確認)
 
 ## ロールバック
 


### PR DESCRIPTION
## 概要

ubuntu-24.04_armv8 platform の cross-compile wheel ビルドを sysroot.py 経路で復活させる。 0024 で multistrap → sysroot.py の置き換えは完了していたが、 cross 経路の cmake 呼び出しと CI matrix の exclude を外していなかったため、 本 PR で経路を最初から最後まで通す。

## 変更内容

- `cmake/toolchains/aarch64-linux-gnu.cmake` を新設 (aarch64-linux-gnu 共通)
- `cmake/scripts/fetch_deps.cmake` の `_SORA_ALLOWED_PLATFORMS` に `ubuntu-24.04_armv8` を追加し、 メインスクリプトに cross 分岐を入れて `_sora_fetch_rootfs` で sysroot を構築。 sanity check は `file(REAL_PATH)` で正規化し、 空 `CMAKE_SYSROOT` を早期検出
- `CMakeLists.txt` の cross 分岐で `NB_SUFFIX` と `SORA_GEN_PYI` を確定 (`Python_VERSION_MAJOR` / `Python_VERSION_MINOR` から組み立て)
- `pyproject.toml` の cross 用 override は **0 件** とし、 CI step の `CMAKE_ARGS` 環境変数経由で cmake 変数を渡す経路に変更
- `.github/workflows/build.yml` の `exclude:` から `ubuntu-24.04_armv8` を外し、 `timeout-minutes` を 60 に引き上げ、 cross 用 build step と 4 段の Verify step を追加
- `CHANGES.md` に `[ADD]` エントリを追記。 0024 由来 `[CHANGE]` の事実誤認 1 行を削除

## 設計変更点 (issue 本文との差分)

issue 本文では pyproject.toml に Python ABI 別 cross 用 override を 3 件追加する設計だったが、 cross platform を追加するたびに override が 3 件ずつ増える冗長性を避けるため、 以下に変更した:

- pyproject.toml の cross 用 override は **0 件**
- `CMAKE_TOOLCHAIN_FILE` / `CMAKE_C_COMPILER_WORKS` / `CMAKE_CXX_COMPILER_WORKS` / `SORA_PYTHON_SDK_PLATFORM` は CI step の `CMAKE_ARGS` 環境変数で cmake コマンドラインに直接渡す
- `NB_SUFFIX` と `SORA_GEN_PYI` は `CMakeLists.txt` の cross 分岐で確定

加えて、 1 周目のレビューで以下の致命的バグを修正:

- `if(NOT CMAKE_SYSROOT STREQUAL _ROOTFS_DIR)` の右辺が unquoted で CMP0054 NEW のもとで常に FATAL_ERROR 発火 → 両辺を `"${...}"` で展開し `file(REAL_PATH)` で正規化

## 事前確認 (ローカル macOS で実施済み)

- [x] prebuilt artifact 3 件の HTTP 200 確認 (webrtc / sora-cpp-sdk / boost、 ubuntu-24.04_armv8)
- [x] `cmake -P cmake/toolchains/aarch64-linux-gnu.cmake` で構文エラーなし
- [x] `uv run python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` pass
- [x] `uv run ruff format --check` pass

## 完了条件 (CI 上で確認)

- [x] `cmake/toolchains/aarch64-linux-gnu.cmake` が新設されている
- [x] `cmake/scripts/fetch_deps.cmake` の `_SORA_ALLOWED_PLATFORMS` に `ubuntu-24.04_armv8` が含まれている
- [x] `cmake/scripts/fetch_deps.cmake` のメインスクリプトで cross 系 platform 時に `_sora_fetch_rootfs` が呼ばれ、 sanity check が入っている
- [x] `pyproject.toml` の cross 用 override は 0 件 (CMAKE_ARGS 経由で渡す経路に統一)
- [x] `.github/workflows/build.yml` の `exclude:` から `ubuntu-24.04_armv8` が外れている
- [x] `.github/workflows/build.yml` の `build_ubuntu` job に cross 用 build step / Verify step が追加され、 `timeout-minutes: 60` に変更されている
- [x] `CHANGES.md` の `## develop` セクションに `[ADD]` エントリが既存 sysroot.py `[ADD]` の直後に追加されている
- [ ] CI で `ubuntu-24.04_armv8` × 3 Python (3.12 / 3.13 / 3.14) の wheel が artifact として生成され、 `build_ubuntu` job が green (CI で観察)
- [ ] 生成された wheel ファイル名が `sora_sdk-<version>-cp3XX-cp3XX-linux_aarch64.whl` 形式 (CI で観察)
- [ ] wheel 内 `sora_sdk_ext.cpython-3XX-aarch64-linux-gnu.so` の `file` 出力が `ELF 64-bit LSB shared object, ARM aarch64` を含む (CI Verify step)

## 関連 issue

- issues/closed/0030-add-ubuntu-24-04-armv8-cross-build.md