### PR TITLE
音声コールバックで GIL を取得する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,9 @@
 - [FIX] `SoraConnection::OnPush` が GIL を取得せずに Python コールバックを呼んでいた問題を修正する
   - GIL 非保持の内部スレッドから Python C API を呼ぶ未定義動作であり、参照カウント競合によるメモリ破壊で `push` 受信時にプロセスが SIGSEGV でクラッシュしうる問題があった
   - @sile
+- [FIX] 音声コールバックが GIL を取得せずに Python を呼び出していた問題を修正する
+  - `SoraAudioSink` と `SoraAudioStreamSink` の音声コールバックを GIL 保持下で実行する
+  - @voluntas
 - [FIX] `SoraConnection` の `connection_tp_clear` が `on_rpc_` を解放していなかった問題を修正する
   - `connection_tp_traverse` は `on_rpc_` を `Py_VISIT` で GC に報告しているのに `connection_tp_clear` が解放しておらず、traverse/clear が非対称で CPython の循環 GC の契約に反していた
   - `on_rpc` ハンドラを含む参照循環を循環 GC が断ち切れず接続オブジェクトのグラフ全体がリークしうる問題があった

--- a/issues/closed/0013-bug-fix-append-data-callback-missing-gil.md
+++ b/issues/closed/0013-bug-fix-append-data-callback-missing-gil.md
@@ -2,8 +2,9 @@
 
 - Priority: Low
 - Created: 2026-06-02
+- Completed: 2026-07-13
 - Model: Opus 4.8
-- Branch: feature/fix-append-data-callback-missing-gil
+- Branch: feature/fix-audio-on-data-missing-gil
 
 ## pending にした理由
 
@@ -127,3 +128,8 @@ pending のため確定しない。A 案を採る場合は以下を満たすこ�
   コールバックを呼ぶ未定義動作」。本 issue の手本となる先例。
 - `issues/0012-bug-fix-audio-sink-read-holds-gil.md` (または closed): 本 issue の
   発見契機。0012 のスコープ外として切り出した。
+
+## 解決方法
+
+issue 0018 が本 issue の対象範囲を引き継ぎ、`SoraAudioSinkImpl::AppendData` の先頭で GIL を取得する修正を実施した。
+`on_format_`、`on_data_`、`nb::ndarray` の構築を GIL 保持下で実行し、実接続テストで callback の発火と引数を確認した。

--- a/issues/closed/0018-bug-fix-audio-on-data-missing-gil.md
+++ b/issues/closed/0018-bug-fix-audio-on-data-missing-gil.md
@@ -3,6 +3,7 @@
 - Priority: High
 - Created: 2026-06-23
 - Polished: 2026-07-13
+- Completed: 2026-07-13
 - Model: Opus 4.7
 - Branch: feature/fix-audio-on-data-missing-gil
 
@@ -185,10 +186,23 @@ Python 公開 API は削除・改名せず、`on_data`、`on_format`、`on_frame
 
 ## 関連 issue
 
-- `issues/pending/0013-bug-fix-append-data-callback-missing-gil.md`: `SoraAudioSinkImpl::AppendData` の `on_format_` / `on_data_` を対象にした pending issue。0018 が対象範囲を引き継ぎ、`SoraAudioStreamSinkImpl::OnData` も含めて扱う。
+- `issues/closed/0013-bug-fix-append-data-callback-missing-gil.md`: `SoraAudioSinkImpl::AppendData` の `on_format_` / `on_data_` を対象にした pending issue。0018 が対象範囲を引き継ぎ、`SoraAudioStreamSinkImpl::OnData` も含めて扱う。
 - `issues/0019-bug-fix-frame-transformer-missing-gil.md`: frame transformer の別の GIL 未取得問題。対象シンボルは重複しない。
 - `issues/closed/0009-bug-fix-on-push-missing-gil.md`: GIL 非保持で Python callback を呼ぶ問題を修正した先例。
 - `issues/closed/0012-bug-fix-audio-sink-read-holds-gil.md`: `Read` の GIL 解放と `GILMutexLock` 導入の先例。
 - `issues/closed/0014-bug-fix-read-pyerr-checksignals-not-propagated.md`: `Read` の Python 例外伝播を修正した先例。
 - `issues/0055-refactor-sora-connection-callbacks-private.md`: 廃止予定の `on_data_` / `on_format_` を当面維持し、次のメジャーで除去する方針。0018 ではこの API 方針を変更しない。
 - `issues/0057-bug-fix-gil-scope-uninitialized-member.md`: `gil_scoped_acquire` の終了処理時の未初期化メンバを扱う別 issue。0018 では `src/gil.h` を変更しない。
+
+## 解決方法
+
+`SoraAudioSinkImpl::AppendData` の先頭で GIL を取得し、`buffer_mtx_` の取得、`on_format_` の呼び出し、`nb::ndarray` の構築、`on_data_` の呼び出しを GIL 保持下で実行するようにした。
+また、`number_of_channels_` を mutex 保持中に snapshot し、mutex 解放後の `on_data_` の shape に使用することで、既存の `(frames, channels)` の shape を維持した。
+
+`SoraAudioStreamSinkImpl::OnData` では `on_frame_` の読み出しと `SoraAudioFrame` の構築前に GIL を取得した。
+さらに、音声 sink の `RemoveSink()` 待機中に GIL を保持して callback 側と相互待ちにならないよう、待機区間だけ GIL を解放するようにした。
+
+実接続の `tests/test_audio_sink_callbacks.py` を追加し、`on_format` と `on_data` の callback 発火、引数、実行スレッドを検証した。
+`tests/test_vad.py` では `on_frame` callback の発火を待機してから統計を確認し、失敗時も接続を解放するようにした。
+
+あわせて、対象範囲を引き継いだ pending issue 0013 を closed へ移動した。

--- a/src/sora_audio_sink.cpp
+++ b/src/sora_audio_sink.cpp
@@ -1,7 +1,7 @@
 #include "sora_audio_sink.h"
 
-#include <span>
 #include <chrono>
+#include <span>
 
 // WebRTC
 #include <api/audio/channel_layout.h>
@@ -40,7 +40,14 @@ void SoraAudioSinkImpl::Disposed() {
   if (track_ && track_->GetTrack()) {
     webrtc::AudioTrackInterface* audio_track =
         static_cast<webrtc::AudioTrackInterface*>(track_->GetTrack().get());
-    audio_track->RemoveSink(this);
+    // 音声スレッドは sink のロックを保持して callback を呼ぶため、
+    // RemoveSink() の待機中に GIL を保持すると callback 側と相互待ちになる。
+    if (PyGILState_Check()) {
+      gil_scoped_release release;
+      audio_track->RemoveSink(this);
+    } else {
+      audio_track->RemoveSink(this);
+    }
   }
   track_ = nullptr;
 }
@@ -104,6 +111,8 @@ void SoraAudioSinkImpl::AppendData(const int16_t* audio_data,
                                    int sample_rate,
                                    size_t number_of_channels,
                                    size_t number_of_frames) {
+  gil_scoped_acquire acq;
+  size_t callback_number_of_channels = 0;
   {
     std::unique_lock<std::mutex> lock(buffer_mtx_);
 
@@ -117,6 +126,8 @@ void SoraAudioSinkImpl::AppendData(const int16_t* audio_data,
       }
     }
 
+    callback_number_of_channels = number_of_channels_;
+
     const size_t num_elements = number_of_channels_ * number_of_frames;
     buffer_.AppendData(num_elements, [&](std::span<int16_t> buf) {
       memcpy(buf.data(), audio_data, num_elements * sizeof(int16_t));
@@ -127,7 +138,7 @@ void SoraAudioSinkImpl::AppendData(const int16_t* audio_data,
   }
 
   if (on_data_) {
-    size_t shape[2] = {number_of_frames, number_of_channels_};
+    size_t shape[2] = {number_of_frames, callback_number_of_channels};
     auto data = nb::ndarray<nb::numpy, int16_t, nb::shape<-1, -1>>(
         (void*)audio_data, 2, shape, nb::handle());
     /* まだ使ったことながない。現状 Python 側で on_frame と同じ感覚でコールバックの外に値を持ち出すと落ちるはず。 */

--- a/src/sora_audio_stream_sink.cpp
+++ b/src/sora_audio_stream_sink.cpp
@@ -10,6 +10,7 @@
 #include <modules/audio_processing/agc2/rnn_vad/common.h>
 #include <modules/audio_processing/include/audio_frame_view.h>
 
+#include "gil.h"
 #include "sora_call.h"
 
 SoraAudioFrameDefaultImpl::SoraAudioFrameDefaultImpl(
@@ -164,7 +165,14 @@ void SoraAudioStreamSinkImpl::Disposed() {
   if (track_ && track_->GetTrack()) {
     webrtc::AudioTrackInterface* audio_track =
         static_cast<webrtc::AudioTrackInterface*>(track_->GetTrack().get());
-    audio_track->RemoveSink(this);
+    // 音声スレッドは sink のロックを保持して callback を呼ぶため、
+    // RemoveSink() の待機中に GIL を保持すると callback 側と相互待ちになる。
+    if (PyGILState_Check()) {
+      gil_scoped_release release;
+      audio_track->RemoveSink(this);
+    } else {
+      audio_track->RemoveSink(this);
+    }
   }
   track_ = nullptr;
 }
@@ -206,6 +214,7 @@ void SoraAudioStreamSinkImpl::OnData(
     webrtc::RemixFrame(output_channels_, tuned_frame.get());
   }
 
+  gil_scoped_acquire acq;
   call_python(on_frame_,
               std::make_shared<SoraAudioFrame>(std::move(tuned_frame)));
 }

--- a/tests/test_apple_video_toolbox.py
+++ b/tests/test_apple_video_toolbox.py
@@ -312,15 +312,15 @@ def test_apple_video_toolbox_simulcast_authz_scale_resolution_to(
 
     assert (
         sendonly.offer_message["encodings"][0]["scaleResolutionDownTo"]["maxWidth"]
-        == simulcast_encodings[0]["scaleResolutionDownTo"]["maxWidth"]  # ty: ignore[invalid-argument-type, not-subscriptable]
+        == simulcast_encodings[0]["scaleResolutionDownTo"]["maxWidth"]
     )
     assert (
         sendonly.offer_message["encodings"][1]["scaleResolutionDownTo"]["maxWidth"]
-        == simulcast_encodings[1]["scaleResolutionDownTo"]["maxWidth"]  # ty: ignore[invalid-argument-type, not-subscriptable]
+        == simulcast_encodings[1]["scaleResolutionDownTo"]["maxWidth"]
     )
     assert (
         sendonly.offer_message["encodings"][2]["scaleResolutionDownTo"]["maxWidth"]
-        == simulcast_encodings[2]["scaleResolutionDownTo"]["maxWidth"]  # ty: ignore[invalid-argument-type, not-subscriptable]
+        == simulcast_encodings[2]["scaleResolutionDownTo"]["maxWidth"]
     )
 
     assert (

--- a/tests/test_audio_sink_callbacks.py
+++ b/tests/test_audio_sink_callbacks.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import threading
+from threading import Event
+
+import numpy
+from client import SoraClient, SoraRole
+from conftest import Settings
+from numpy.typing import NDArray
+
+from sora_sdk import SoraAudioSink, SoraMediaTrack
+
+
+def test_audio_sink_callbacks(settings: Settings) -> None:
+    """音声 sink の廃止予定 callback が実接続で呼び出されることを確認する
+
+    音声 callback は libwebrtc の音声処理スレッドから呼び出される。callback 内で
+    Python のリスト更新と NumPy 配列の属性参照を行い、Python を呼び出す経路が
+    GIL を保持して安全に実行できることを、プロセスのクラッシュなしで確認する。
+    """
+    format_received = Event()
+    data_received = Event()
+    format_values: list[tuple[int, int]] = []
+    data_values: list[tuple[tuple[int, ...], str]] = []
+    callback_thread_ids: set[int] = set()
+    main_thread_id = threading.get_ident()
+    audio_sinks: list[SoraAudioSink] = []
+
+    def on_format(sample_rate: int, number_of_channels: int) -> None:
+        # callback の引数を Python オブジェクトへ保存し、GIL 保持下の処理を確認する
+        format_values.append((sample_rate, number_of_channels))
+        callback_thread_ids.add(threading.get_ident())
+        format_received.set()
+
+    def on_data(data: NDArray[numpy.int16]) -> None:
+        # ndarray の shape と dtype を callback の中で参照して記録する
+        data_values.append((tuple(int(value) for value in data.shape), str(data.dtype)))
+        callback_thread_ids.add(threading.get_ident())
+        data_received.set()
+
+    def on_track(track: SoraMediaTrack) -> None:
+        if track.kind != "audio":
+            return
+
+        # sink の生成直後に callback を設定し、音声データ到着後のポーリングで
+        # 最初のフォーマット通知を取り逃がさないようにする
+        audio_sink = SoraAudioSink(track, output_frequency=16000, output_channels=1)
+        audio_sink.on_format = on_format
+        audio_sink.on_data = on_data
+        audio_sinks.append(audio_sink)
+
+    sendonly = SoraClient(settings, SoraRole.SENDONLY, audio=True, video=False)
+    recvonly = SoraClient(
+        settings,
+        SoraRole.RECVONLY,
+        audio=True,
+        video=False,
+        audio_output_frequency=16000,
+        audio_output_channels=1,
+    )
+    recvonly._connection.on_track = on_track
+
+    sendonly_started = False
+    recvonly_started = False
+    try:
+        # 受信側に音声 track を届けるため、送信側で実音声を生成する
+        sendonly_started = True
+        sendonly.connect(fake_audio=True)
+        recvonly_started = True
+        recvonly.connect()
+
+        assert format_received.wait(30), "on_format callback が発火しなかった"
+        assert data_received.wait(30), "on_data callback が発火しなかった"
+
+        assert format_values, "on_format callback の引数が記録されなかった"
+        assert format_values[0][0] == 16000
+        assert format_values[0][1] == 1
+        assert data_values, "on_data callback の引数が記録されなかった"
+        assert len(data_values[0][0]) == 2
+        assert data_values[0][0][0] > 0
+        assert data_values[0][0][1] == 1
+        assert data_values[0][1] == "int16"
+        assert callback_thread_ids
+        assert all(thread_id != main_thread_id for thread_id in callback_thread_ids)
+    finally:
+        # callback の待機と検証を終えてから切断し、音声スレッドの終了処理と競合させない
+        try:
+            if recvonly_started:
+                recvonly.disconnect()
+        finally:
+            try:
+                # 受信側の sink を明示的に破棄してから送信側を切断する
+                audio_sinks.clear()
+            finally:
+                if sendonly_started:
+                    sendonly.disconnect()

--- a/tests/test_authz_simulcast.py
+++ b/tests/test_authz_simulcast.py
@@ -401,15 +401,15 @@ def test_authz_simulcast_scale_resolution_down_to(
 
     assert (
         sendonly.offer_message["encodings"][0]["scaleResolutionDownTo"]["maxWidth"]
-        == simulcast_encodings[0]["scaleResolutionDownTo"]["maxWidth"]  # ty: ignore[invalid-argument-type, not-subscriptable]
+        == simulcast_encodings[0]["scaleResolutionDownTo"]["maxWidth"]
     )
     assert (
         sendonly.offer_message["encodings"][1]["scaleResolutionDownTo"]["maxWidth"]
-        == simulcast_encodings[1]["scaleResolutionDownTo"]["maxWidth"]  # ty: ignore[invalid-argument-type, not-subscriptable]
+        == simulcast_encodings[1]["scaleResolutionDownTo"]["maxWidth"]
     )
     assert (
         sendonly.offer_message["encodings"][2]["scaleResolutionDownTo"]["maxWidth"]
-        == simulcast_encodings[2]["scaleResolutionDownTo"]["maxWidth"]  # ty: ignore[invalid-argument-type, not-subscriptable]
+        == simulcast_encodings[2]["scaleResolutionDownTo"]["maxWidth"]
     )
 
     assert (

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -47,6 +47,8 @@ class VAD:
         self._connected: Event = Event()
         # 終了
         self._disconnected = Event()
+        # 音声フレームを受け取り、VAD の解析が完了したことを通知する
+        self._frame_received: Event = Event()
 
         self._audio_output_frequency: int = 24000
         self._audio_output_channels: int = 1
@@ -112,6 +114,7 @@ class VAD:
             print(f"Voice! voice_probability={voice_probability}")
         else:
             pass
+        self._frame_received.set()
 
     def _on_track(self, track: SoraMediaTrack):
         if track.kind == "audio":
@@ -129,18 +132,29 @@ def test_vad(settings):
         audio=True,
         video=False,
     )
-    sendonly.connect(fake_audio=True)
-
     vad = VAD(settings)
-    vad.connect()
+    sendonly_started = False
+    vad_started = False
+    try:
+        sendonly_started = True
+        sendonly.connect(fake_audio=True)
+        vad_started = True
+        vad.connect()
 
-    time.sleep(5)
+        # on_frame callback が実際に発火し、VAD の解析まで完了することを確認する
+        assert vad._frame_received.wait(30), "音声フレームの callback が発火しなかった"
+        # 接続統計が揃うまで既存の観測時間を確保する
+        time.sleep(5)
 
-    sendonly_stats = sendonly.get_stats()
-    vad_stats = vad.get_stats()
-
-    sendonly.disconnect()
-    vad.disconnect()
+        sendonly_stats = sendonly.get_stats()
+        vad_stats = vad.get_stats()
+    finally:
+        try:
+            if vad_started:
+                vad.disconnect()
+        finally:
+            if sendonly_started:
+                sendonly.disconnect()
 
     # codec が無かったら StopIteration 例外が上がる
     sendonly_codec_stats = next(s for s in sendonly_stats if s.get("type") == "codec")


### PR DESCRIPTION
## 概要

- SoraAudioSink と SoraAudioStreamSink の音声コールバック前に GIL を取得する
- RemoveSink 待機中の GIL と音声 callback の相互待ちを防ぐ
- 実接続テストと VAD callback 発火確認を追加する
- pending の issue 0013 と issue 0018 を closed へ移動する

## 確認

- `uv run pytest -q`: 61 passed, 99 skipped, 1 xfailed
- `prek run`: 成功
- callback テスト 10 回反復: 成功

残った既存警告: tests/client.py の fake video thread による PytestUnhandledThreadExceptionWarning 5 件。