### PR TITLE
deprecated な tool.scikit-build.metadata を tool.dynamic-metadata に移行する

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ TARGET_OS = "ubuntu"
 [tool.scikit-build.wheel]
 packages = ["src/sora_sdk"]
 
-[tool.scikit-build.metadata.version]
+[[tool.dynamic-metadata]]
 provider = "scikit_build_core.metadata.regex"
 input = "VERSION"
 regex = "(?P<value>\\S+)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ TARGET_OS = "ubuntu"
 packages = ["src/sora_sdk"]
 
 [[tool.dynamic-metadata]]
+field = "version"
 provider = "scikit_build_core.metadata.regex"
 input = "VERSION"
 regex = "(?P<value>\\S+)"


### PR DESCRIPTION
## 概要

scikit-build-core 1.0.3 で `tool.scikit-build.metadata` が deprecated になり、CI ビルド時に WARNING が出力されていた。標準の `[[tool.dynamic-metadata]]` に移行する。

## 変更内容

- `[tool.scikit-build.metadata.version]` を `[[tool.dynamic-metadata]]` に置換（内容は同一）