### PR TITLE
0035 ConvertJsonValue の整数変換を int64_t にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,9 @@
 - [FIX] `SoraVideoSource` に `Disposed` override が無くワーカスレッド停止がデストラクタ依存だった問題を修正する
   - `Disposed()` で `finished_` を立てて待機解除し、`join` はデストラクタに残す
   - @voluntas
+- [FIX] `Sora::ConvertJsonValue` が Python 整数を `int` にキャストして int32 範囲超で例外になる問題を修正する
+  - `nb::cast<int64_t>` に切り替え、JWT の `exp` など大きな整数を通せるようにする
+  - @voluntas
 - [FIX] `Sora` の破棄順序が原因で GC のタイミング次第にプロセスが SIGSEGV でクラッシュしうる問題を修正する
   - `Sora::~Sora` が `PeerConnectionFactory` を先に破棄した後に io_context を破棄していたため、io_context に残った handler が握る `sora::SoraSignaling` の破棄が破棄済みの signaling スレッドへ Marshal して use-after-free になっていた
   - 破棄順序を「子への破棄通知 → io_context の停止・破棄 → factory の破棄」に修正する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,7 +71,7 @@
   - `Disposed()` で `finished_` を立てて待機解除し、`join` はデストラクタに残す
   - @voluntas
 - [FIX] `Sora::ConvertJsonValue` が Python 整数を `int` にキャストして int32 範囲超で例外になる問題を修正する
-  - `nb::cast<int64_t>` に切り替え、JWT の `exp` など大きな整数を通せるようにする
+  - `PyLong_Check` と `nb::cast<int64_t>` で大きな整数を通し、`bool` 分岐は先に維持する
   - @voluntas
 - [FIX] `Sora` の破棄順序が原因で GC のタイミング次第にプロセスが SIGSEGV でクラッシュしうる問題を修正する
   - `Sora::~Sora` が `PeerConnectionFactory` を先に破棄した後に io_context を破棄していたため、io_context に残った handler が握る `sora::SoraSignaling` の破棄が破棄済みの signaling スレッドへ Marshal して use-after-free になっていた

--- a/src/sora.cpp
+++ b/src/sora.cpp
@@ -331,7 +331,8 @@ boost::json::value Sora::ConvertJsonValue(nb::handle value,
   } else if (nb::isinstance<bool>(value)) {
     return nb::cast<bool>(value);
   } else if (nb::isinstance<int>(value)) {
-    return nb::cast<int>(value);
+    // Python int は任意精度。int32 範囲を超える JWT exp 等を通すため int64_t にする
+    return nb::cast<int64_t>(value);
   } else if (nb::isinstance<float>(value)) {
     return nb::cast<float>(value);
   } else if (nb::isinstance<const char*>(value)) {

--- a/src/sora.cpp
+++ b/src/sora.cpp
@@ -330,8 +330,9 @@ boost::json::value Sora::ConvertJsonValue(nb::handle value,
     return nullptr;
   } else if (nb::isinstance<bool>(value)) {
     return nb::cast<bool>(value);
-  } else if (nb::isinstance<int>(value)) {
-    // Python int は任意精度。int32 範囲を超える JWT exp 等を通すため int64_t にする
+  } else if (PyLong_Check(value.ptr())) {
+    // nb::isinstance<int> は C++ int に収まらない Python int で false になるため
+    // PyLong_Check で任意精度整数を受け取り、int64_t へ変換する
     return nb::cast<int64_t>(value);
   } else if (nb::isinstance<float>(value)) {
     return nb::cast<float>(value);

--- a/tests/test_convert_json_value_int64.py
+++ b/tests/test_convert_json_value_int64.py
@@ -1,0 +1,54 @@
+"""
+ConvertJsonValue が int32 範囲を超える Python 整数を受け付けることを検証する。
+
+metadata 等の JSON 変換経路で nb::cast<int> だと 2**31 超で例外になる。
+"""
+
+from __future__ import annotations
+
+from sora_sdk import Sora
+
+
+def test_create_connection_accepts_int64_metadata():
+    """
+    metadata に int32 を超える整数を渡しても create_connection が成功すること。
+
+    前提:
+    - ConvertJsonValue が metadata の整数を boost::json::value に変換する
+
+    期待:
+    - 2**40 を含む metadata で例外にならない
+    """
+    sora = Sora()
+    connection = sora.create_connection(
+        signaling_urls=["wss://example.invalid/signaling"],
+        role="recvonly",
+        channel_id="convert-json-int64",
+        metadata={"exp": 2**40},
+        audio=False,
+        video=False,
+    )
+    assert connection is not None
+
+
+def test_create_connection_keeps_bool_before_int_branch():
+    """
+    metadata の True / False が create_connection で例外にならないこと。
+
+    前提:
+    - Python では bool は int のサブクラス
+    - ConvertJsonValue は bool 分岐を int 分岐より先に評価する
+
+    期待:
+    - True / False を含む metadata で例外にならない
+    """
+    sora = Sora()
+    connection = sora.create_connection(
+        signaling_urls=["wss://example.invalid/signaling"],
+        role="recvonly",
+        channel_id="convert-json-bool",
+        metadata={"enabled": True, "disabled": False},
+        audio=False,
+        video=False,
+    )
+    assert connection is not None


### PR DESCRIPTION
## Summary
- `Sora::ConvertJsonValue` の整数キャストを `int` から `int64_t` に変更する
- JWT の `exp` など int32 範囲を超える整数が例外にならないようにする
- `bool` 分岐を `int` 分岐より先に置く順序は維持する

## Test plan
- [x] ソースのみの push で build.yml の e2e が PASS
- [ ] テスト追加後の e2e-test.yml が PASS